### PR TITLE
feat: markdown preview for .md files

### DIFF
--- a/docs/superpowers/specs/2026-04-06-markdown-preview-design.md
+++ b/docs/superpowers/specs/2026-04-06-markdown-preview-design.md
@@ -1,0 +1,99 @@
+# Markdown Preview — Design Spec
+
+**Date:** 2026-04-06
+**Branch:** `enhance/resizeable-area`
+**Status:** Approved
+
+## Overview
+
+Add a right-click context menu to `.md` files in the file list that opens a centered modal overlay rendering the file as full-featured GitHub-Flavored Markdown with syntax-highlighted code blocks.
+
+## Trigger & Interaction
+
+- Right-clicking a `.md` file node in `FileList` opens a Radix `ContextMenu` with a single "Preview" item.
+- Non-`.md` files are unaffected — no context menu is added for them.
+- Clicking "Preview" opens the markdown preview modal.
+- The modal is dismissed by: ESC key, clicking the backdrop, or clicking the close button in the modal header.
+
+## Components
+
+### `FileList.tsx` (modified)
+
+- `TreeNode` gains an `onPreview?: (path: string) => void` prop.
+- For `.md` files, the existing `<button>` is wrapped in `@radix-ui/react-context-menu` (`Root`, `Trigger`, `Portal`, `Content`, `Item`).
+- `FileList` holds `previewPath: string | null` state. "Preview" item calls `onPreview(node.path)`, which sets `previewPath`. Closing the modal resets it to `null`.
+
+### `MarkdownPreviewModal.tsx` (new — `src/features/viewer/`)
+
+Props:
+```ts
+interface Props {
+  worktreePath: string;
+  relativePath: string;
+  open: boolean;
+  onClose: () => void;
+}
+```
+
+- Wraps content in `@radix-ui/react-dialog` (`Root`, `Overlay`, `Content`).
+- Modal header: filename (`relativePath`) on the left, close button (`✕`) on the right.
+- On open: calls `files.read(worktreePath, relativePath)` to fetch content.
+- Loading state: shown while fetch is in progress.
+- Error state: inline error message + Retry button (re-triggers `files.read`).
+- Success state: renders content via `react-markdown` with `remark-gfm` and `rehype-highlight`.
+- Modal body is scrollable for long documents.
+
+## Data Flow
+
+1. User right-clicks `.md` file → Radix `ContextMenu` opens.
+2. User clicks "Preview" → `onPreview(node.path)` → `FileList` sets `previewPath = node.path`.
+3. `MarkdownPreviewModal` mounts with `open=true` → fetches file via `files.read(worktreePath, relativePath)`.
+4. Content renders via `react-markdown`. Loading and error states shown as appropriate.
+5. User dismisses modal → `onClose` → `FileList` sets `previewPath = null`.
+
+File content is fetched fresh on each open. No caching in V1.
+
+## Markdown Rendering
+
+**New dependencies:**
+- `react-markdown` — core renderer
+- `remark-gfm` — GitHub-Flavored Markdown (tables, task lists, strikethrough, autolinks)
+- `rehype-highlight` — syntax highlighting in fenced code blocks
+
+**Rendered features:** headings, bold/italic, inline code, fenced code blocks with language-aware syntax highlighting, tables, task lists, strikethrough, blockquotes, links.
+
+## Error Handling
+
+| Scenario | Behaviour |
+|---|---|
+| `files.read` fails | Inline error message + Retry button inside the modal |
+| Empty file | Renders normally (`react-markdown` handles empty string) |
+| Very large file | Modal is scrollable; no size cap in V1 |
+| Non-`.md` right-click | No context menu shown |
+
+## Visual Design
+
+- Centered overlay, approximately 80% viewport width.
+- Dark backdrop (`rgba(0,0,0,0.6)`).
+- Modal body uses `@radix-ui/react-scroll-area` (already installed) for the scrollable content area.
+- Styling follows existing `shell-*` CSS conventions.
+
+## Testing
+
+### Unit Tests
+
+**`MarkdownPreviewModal`:**
+- Renders headings, bold/italic, inline code, fenced code blocks (with language class), GFM tables, task lists, strikethrough.
+- Shows loading state while fetching.
+- Shows error message + Retry button on fetch failure; Retry re-fetches.
+
+**`TreeNode` / `FileList`:**
+- Context menu is rendered for `.md` files only.
+- "Preview" item calls `onPreview` with the correct path.
+- Non-`.md` files have no context menu.
+
+### E2E Tests
+
+- Right-click a `.md` file → "Preview" appears in context menu.
+- Click "Preview" → modal opens with rendered markdown content.
+- ESC key closes the modal.

--- a/docs/superpowers/specs/2026-04-06-markdown-preview-design.md
+++ b/docs/superpowers/specs/2026-04-06-markdown-preview-design.md
@@ -2,20 +2,36 @@
 
 **Date:** 2026-04-06
 **Branch:** `enhance/resizeable-area`
-**Status:** Approved
+**Status:** Approved — updated 2026-04-07 (scroll fix + viewer panel preview)
 
 ## Overview
 
 Add a right-click context menu to `.md` files in the file list that opens a centered modal overlay rendering the file as full-featured GitHub-Flavored Markdown with syntax-highlighted code blocks.
 
+**Amendment (2026-04-07):** Two follow-up items based on testing:
+1. **Scroll fix** — long markdown content in the modal did not scroll due to a CSS flex layout issue.
+2. **Viewer panel preview** — right-clicking the viewer panel header (where Monaco displays the current file) also offers "Preview" for `.md` files, using the same modal.
+
 ## Trigger & Interaction
 
+**File list (FileList):**
 - Right-clicking a `.md` file node in `FileList` opens a Radix `ContextMenu` with a single "Preview" item.
 - Non-`.md` files are unaffected — no context menu is added for them.
 - Clicking "Preview" opens the markdown preview modal.
 - The modal is dismissed by: ESC key, clicking the backdrop, or clicking the close button in the modal header.
 
+**Viewer panel (FileViewer):**
+- Right-clicking anywhere on the `shell-viewer__header` area opens a Radix `ContextMenu` with a "Preview" item, but only when the currently-displayed file is a `.md` file.
+- For non-`.md` files, no context menu is shown in the header.
+- Note: Monaco editor captures pointer events internally — the context menu trigger covers the viewer header only, not the Monaco editor canvas. This is expected behaviour.
+
 ## Components
+
+### `MarkdownPreviewModal.tsx` — scroll fix
+
+The modal's scrollable region uses `@radix-ui/react-scroll-area`. Inside a flex column layout, the `ScrollArea.Root` must have `min-height: 0` to shrink below its natural content height and enable overflow scrolling. The fix is:
+- Add `min-height: 0` to `.shell-md-modal__scroll` in `shell.css`.
+- Ensure `.shell-md-modal__body` (the `ScrollArea.Viewport`) has `height: 100%`.
 
 ### `FileList.tsx` (modified)
 
@@ -43,15 +59,29 @@ interface Props {
 - Success state: renders content via `react-markdown` with `remark-gfm` and `rehype-highlight`.
 - Modal body is scrollable for long documents.
 
+### `FileViewer.tsx` (new context menu)
+
+- Wrap the `shell-viewer__header` div in `@radix-ui/react-context-menu` (`Root`, `Trigger`, `Portal`, `Content`, `Item`).
+- Show the "Preview" `ContextMenu.Item` only when `relativePath.endsWith('.md')`.
+- `FileViewer` manages `previewOpen: boolean` state locally. "Preview" sets it to `true`; `onClose` resets it to `false`.
+- Renders `<MarkdownPreviewModal>` when `previewOpen` is true, using the existing `worktreePath` and `relativePath` props.
+
 ## Data Flow
 
-1. User right-clicks `.md` file → Radix `ContextMenu` opens.
+**File list path:**
+1. User right-clicks `.md` file in FileList → Radix `ContextMenu` opens.
 2. User clicks "Preview" → `onPreview(node.path)` → `FileList` sets `previewPath = node.path`.
 3. `MarkdownPreviewModal` mounts with `open=true` → fetches file via `files.read(worktreePath, relativePath)`.
 4. Content renders via `react-markdown`. Loading and error states shown as appropriate.
 5. User dismisses modal → `onClose` → `FileList` sets `previewPath = null`.
 
-File content is fetched fresh on each open. No caching in V1.
+**Viewer panel path:**
+1. User right-clicks the viewer header → Radix `ContextMenu` opens (only for `.md` files).
+2. User clicks "Preview" → `FileViewer` sets `previewOpen = true`.
+3. `MarkdownPreviewModal` mounts, fetches, and renders the same file already loaded in the viewer.
+4. User dismisses modal → `onClose` → `FileViewer` sets `previewOpen = false`.
+
+File content is fetched fresh on each modal open. No caching in V1.
 
 ## Markdown Rendering
 
@@ -68,7 +98,7 @@ File content is fetched fresh on each open. No caching in V1.
 |---|---|
 | `files.read` fails | Inline error message + Retry button inside the modal |
 | Empty file | Renders normally (`react-markdown` handles empty string) |
-| Very large file | Modal is scrollable; no size cap in V1 |
+| Very large file | Modal is scrollable (after scroll fix); no size cap in V1 |
 | Non-`.md` right-click | No context menu shown |
 
 ## Visual Design
@@ -92,8 +122,15 @@ File content is fetched fresh on each open. No caching in V1.
 - "Preview" item calls `onPreview` with the correct path.
 - Non-`.md` files have no context menu.
 
+**`FileViewer`:**
+- Right-clicking the header on a `.md` file shows a "Preview" context menu item.
+- Right-clicking the header on a non-`.md` file shows no context menu.
+- Clicking "Preview" opens the `MarkdownPreviewModal` (shows loading state).
+
 ### E2E Tests
 
-- Right-click a `.md` file → "Preview" appears in context menu.
+- Right-click a `.md` file in FileList → "Preview" appears in context menu.
 - Click "Preview" → modal opens with rendered markdown content.
 - ESC key closes the modal.
+- Right-click the viewer panel header when a `.md` file is selected → "Preview" context menu appears.
+- Click "Preview" → same modal opens.

--- a/package.json
+++ b/package.json
@@ -30,10 +30,14 @@
 		"@radix-ui/react-tabs": "^1.1.0",
 		"@radix-ui/react-tooltip": "^1.2.0",
 		"@xterm/addon-fit": "^0.11.0",
+		"highlight.js": "^11.11.1",
 		"monaco-editor": "^0.55.1",
 		"node-pty": "^1.1.0",
 		"react": "^19.2.4",
 		"react-dom": "^19.2.4",
+		"react-markdown": "^10.1.0",
+		"rehype-highlight": "^7.0.2",
+		"remark-gfm": "^4.0.1",
 		"xterm": "^5.3.0",
 		"zod": "^4.3.6"
 	},
@@ -55,7 +59,9 @@
 		"@types/react": "^19.2.14",
 		"@types/react-dom": "^19.2.3",
 		"@vitejs/plugin-react": "^4.7.0",
+		"builder-util": "^26.0.0",
 		"electron": "^41.1.1",
+		"electron-builder": "^26.0.12",
 		"electron-vite": "^5.0.0",
 		"eslint": "^9.25.1",
 		"eslint-plugin-react-hooks": "^5.2.0",
@@ -65,8 +71,6 @@
 		"typescript": "^6.0.2",
 		"typescript-eslint": "^8.30.1",
 		"vite": "^6.4.1",
-		"vitest": "^4.1.2",
-		"electron-builder": "^26.0.12",
-		"builder-util": "^26.0.0"
+		"vitest": "^4.1.2"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@xterm/addon-fit':
         specifier: ^0.11.0
         version: 0.11.0
+      highlight.js:
+        specifier: ^11.11.1
+        version: 11.11.1
       monaco-editor:
         specifier: ^0.55.1
         version: 0.55.1
@@ -47,6 +50,15 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.14)(react@19.2.4)
+      rehype-highlight:
+        specifier: ^7.0.2
+        version: 7.0.2
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       xterm:
         specifier: ^5.3.0
         version: 5.3.0
@@ -1209,11 +1221,17 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/fs-extra@9.0.13':
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
+
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
   '@types/http-cache-semantics@4.2.0':
     resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
@@ -1223,6 +1241,9 @@ packages:
 
   '@types/keyv@3.1.4':
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
@@ -1249,6 +1270,12 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@types/verror@1.10.11':
     resolution: {integrity: sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==}
@@ -1314,6 +1341,9 @@ packages:
   '@typescript-eslint/visitor-keys@8.58.0':
     resolution: {integrity: sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -1453,6 +1483,9 @@ packages:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -1536,6 +1569,9 @@ packages:
   caniuse-lite@1.0.30001784:
     resolution: {integrity: sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -1543,6 +1579,18 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
@@ -1592,6 +1640,9 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@5.1.0:
     resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
@@ -1650,6 +1701,9 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
@@ -1689,6 +1743,9 @@ packages:
 
   detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   dir-compare@4.2.0:
     resolution: {integrity: sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==}
@@ -1823,6 +1880,10 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
   eslint-plugin-react-hooks@5.2.0:
     resolution: {integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==}
     engines: {node: '>=10'}
@@ -1871,6 +1932,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -1884,6 +1948,9 @@ packages:
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   extract-zip@2.0.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
@@ -2064,6 +2131,22 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-is-element@3.0.0:
+    resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
+
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-to-text@4.0.2:
+    resolution: {integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  highlight.js@11.11.1:
+    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+    engines: {node: '>=12.0.0'}
+
   hosted-git-info@4.1.0:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
@@ -2071,6 +2154,9 @@ packages:
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
@@ -2126,9 +2212,21 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -2142,9 +2240,16 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
   is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
     engines: {node: '>=8'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -2322,9 +2427,15 @@ packages:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   lowercase-keys@2.0.0:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
     engines: {node: '>=8'}
+
+  lowlight@3.3.0:
+    resolution: {integrity: sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -2351,6 +2462,9 @@ packages:
     resolution: {integrity: sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   marked@14.0.0:
     resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
     engines: {node: '>= 18'}
@@ -2364,8 +2478,137 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -2546,6 +2789,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
@@ -2633,6 +2879,9 @@ packages:
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -2651,6 +2900,12 @@ packages:
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -2701,6 +2956,21 @@ packages:
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  rehype-highlight@7.0.2:
+    resolution: {integrity: sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -2835,6 +3105,9 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
@@ -2866,6 +3139,9 @@ packages:
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -2881,6 +3157,12 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   sumchecker@3.0.1:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
@@ -2944,6 +3226,12 @@ packages:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   truncate-utf8-bytes@1.0.2:
     resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
 
@@ -2986,6 +3274,9 @@ packages:
     resolution: {integrity: sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==}
     engines: {node: '>=20.18.1'}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
   unique-filename@4.0.0:
     resolution: {integrity: sha512-XSnEewXmQ+veP7xX2dS5Q4yZAvO40cBN2MWkJ7D/6sW4Dg6wYBNwM1Vrnz1FhH5AdeLIlUXRI9e28z1YZi71NQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -2993,6 +3284,24 @@ packages:
   unique-slug@5.0.0:
     resolution: {integrity: sha512-9OdaqO5kwqR+1kVgHAhsp5vPNU0hnxRa26rBFNfNgM7M6pNtgzeBn3s/xbyCQL3dcjzOatcef6UUHpB/6MaETg==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  unist-util-find-after@5.0.0:
+    resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -3040,6 +3349,12 @@ packages:
   verror@1.10.1:
     resolution: {integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==}
     engines: {node: '>=0.6.0'}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite@6.4.1:
     resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
@@ -3211,6 +3526,9 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -4256,11 +4574,19 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
+
   '@types/estree@1.0.8': {}
 
   '@types/fs-extra@9.0.13':
     dependencies:
       '@types/node': 25.5.0
+
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
 
   '@types/http-cache-semantics@4.2.0': {}
 
@@ -4269,6 +4595,10 @@ snapshots:
   '@types/keyv@3.1.4':
     dependencies:
       '@types/node': 25.5.0
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
 
   '@types/ms@2.1.0': {}
 
@@ -4300,6 +4630,10 @@ snapshots:
 
   '@types/trusted-types@2.0.7':
     optional: true
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
 
   '@types/verror@1.10.11':
     optional: true
@@ -4399,6 +4733,8 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.58.0
       eslint-visitor-keys: 5.0.1
+
+  '@ungap/structured-clone@1.3.0': {}
 
   '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
@@ -4563,6 +4899,8 @@ snapshots:
 
   at-least-node@1.0.0: {}
 
+  bail@2.0.2: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -4680,12 +5018,22 @@ snapshots:
 
   caniuse-lite@1.0.30001784: {}
 
+  ccount@2.0.1: {}
+
   chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   chownr@3.0.0: {}
 
@@ -4728,6 +5076,8 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  comma-separated-tokens@2.0.3: {}
 
   commander@5.1.0: {}
 
@@ -4779,6 +5129,10 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
@@ -4815,6 +5169,10 @@ snapshots:
 
   detect-node@2.1.0:
     optional: true
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   dir-compare@4.2.0:
     dependencies:
@@ -5016,6 +5374,8 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  escape-string-regexp@5.0.0: {}
+
   eslint-plugin-react-hooks@5.2.0(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       eslint: 9.39.4(jiti@2.6.1)
@@ -5088,6 +5448,8 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-util-is-identifier-name@3.0.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -5097,6 +5459,8 @@ snapshots:
   expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
+
+  extend@3.0.2: {}
 
   extract-zip@2.0.1:
     dependencies:
@@ -5308,6 +5672,43 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-is-element@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-to-text@4.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      hast-util-is-element: 3.0.0
+      unist-util-find-after: 5.0.0
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  highlight.js@11.11.1: {}
+
   hosted-git-info@4.1.0:
     dependencies:
       lru-cache: 6.0.0
@@ -5317,6 +5718,8 @@ snapshots:
       '@exodus/bytes': 1.15.0
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  html-url-attributes@3.0.1: {}
 
   http-cache-semantics@4.2.0: {}
 
@@ -5371,7 +5774,18 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  inline-style-parser@0.2.7: {}
+
   ip-address@10.1.0: {}
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
+  is-decimal@2.0.1: {}
 
   is-extglob@2.1.1: {}
 
@@ -5381,7 +5795,11 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-hexadecimal@2.0.1: {}
+
   is-interactive@1.0.0: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -5538,7 +5956,15 @@ snapshots:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
 
+  longest-streak@3.1.0: {}
+
   lowercase-keys@2.0.0: {}
+
+  lowlight@3.3.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      devlop: 1.1.0
+      highlight.js: 11.11.1
 
   lru-cache@10.4.3: {}
 
@@ -5574,6 +6000,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  markdown-table@3.0.4: {}
+
   marked@14.0.0: {}
 
   matcher@3.0.0:
@@ -5583,7 +6011,351 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
   mdn-data@2.27.1: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   mime-db@1.52.0: {}
 
@@ -5762,6 +6534,16 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   parse5@8.0.0:
     dependencies:
       entities: 6.0.1
@@ -5837,6 +6619,8 @@ snapshots:
       retry: 0.12.0
       signal-exit: 3.0.7
 
+  property-information@7.1.0: {}
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
@@ -5852,6 +6636,24 @@ snapshots:
       scheduler: 0.27.0
 
   react-is@17.0.2: {}
+
+  react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.14
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 19.2.4
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   react-refresh@0.17.0: {}
 
@@ -5900,6 +6702,48 @@ snapshots:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  rehype-highlight@7.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-to-text: 4.0.2
+      lowlight: 3.3.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   require-directory@2.1.1: {}
 
@@ -6046,6 +6890,8 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
   sprintf-js@1.1.3:
     optional: true
 
@@ -6077,6 +6923,11 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -6090,6 +6941,14 @@ snapshots:
       min-indent: 1.0.1
 
   strip-json-comments@3.1.1: {}
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   sumchecker@3.0.1:
     dependencies:
@@ -6156,6 +7015,10 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
+
   truncate-utf8-bytes@1.0.2:
     dependencies:
       utf8-byte-length: 1.0.5
@@ -6192,6 +7055,16 @@ snapshots:
 
   undici@7.24.7: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
   unique-filename@4.0.0:
     dependencies:
       unique-slug: 5.0.0
@@ -6199,6 +7072,34 @@ snapshots:
   unique-slug@5.0.0:
     dependencies:
       imurmurhash: 0.1.4
+
+  unist-util-find-after@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   universalify@0.1.2: {}
 
@@ -6239,6 +7140,16 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.4.1
     optional: true
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0):
     dependencies:
@@ -6367,3 +7278,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zod@4.3.6: {}
+
+  zwitch@2.0.4: {}

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -1275,3 +1275,9 @@ select {
 	border-color: var(--panel-border-strong);
 	color: var(--text-primary);
 }
+
+.shell-md-modal__close:focus-visible,
+.shell-md-modal__retry:focus-visible {
+	outline: 2px solid var(--accent);
+	outline-offset: 2px;
+}

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -1115,3 +1115,146 @@ select {
 	margin-top: var(--space-4);
 	color: var(--text-secondary);
 }
+
+/* ── Markdown Preview Modal ─────────────────────────────────────────── */
+
+.shell-md-overlay {
+	position: fixed;
+	inset: 0;
+	background: rgba(0, 0, 0, 0.6);
+	z-index: 49;
+}
+
+.shell-md-modal {
+	position: fixed;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+	width: min(80vw, 1000px);
+	max-height: 80vh;
+	display: flex;
+	flex-direction: column;
+	background: var(--panel-bg);
+	border: 1px solid var(--panel-border);
+	border-radius: var(--radius-md);
+	z-index: 50;
+	overflow: hidden;
+}
+
+.shell-md-modal__header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: var(--space-3) var(--space-4);
+	border-bottom: 1px solid var(--panel-border);
+	flex-shrink: 0;
+}
+
+.shell-md-modal__title {
+	font-size: 0.875rem;
+	color: var(--text-primary);
+	font-family: var(--font-terminal);
+	margin: 0;
+}
+
+.shell-md-modal__close {
+	background: transparent;
+	border: none;
+	color: var(--text-muted);
+	cursor: pointer;
+	padding: var(--space-1);
+	line-height: 1;
+	border-radius: var(--radius-sm);
+}
+
+.shell-md-modal__close:hover {
+	color: var(--text-primary);
+	background: var(--panel-bg-elevated);
+}
+
+.shell-md-modal__scroll {
+	flex: 1;
+	overflow: hidden;
+}
+
+.shell-md-modal__body {
+	padding: var(--space-4) var(--space-6);
+	color: var(--text-primary);
+	line-height: 1.6;
+}
+
+.shell-md-modal__body h1,
+.shell-md-modal__body h2,
+.shell-md-modal__body h3,
+.shell-md-modal__body h4,
+.shell-md-modal__body h5,
+.shell-md-modal__body h6 {
+	margin-top: var(--space-4);
+	margin-bottom: var(--space-2);
+	font-weight: 600;
+	color: var(--text-primary);
+}
+
+.shell-md-modal__body p {
+	margin-bottom: var(--space-3);
+}
+
+.shell-md-modal__body pre {
+	background: var(--panel-bg-elevated);
+	padding: var(--space-3);
+	border-radius: var(--radius-sm);
+	overflow-x: auto;
+	margin-bottom: var(--space-3);
+}
+
+.shell-md-modal__body code {
+	font-family: var(--font-terminal);
+	font-size: 0.875rem;
+}
+
+.shell-md-modal__body :not(pre) > code {
+	background: var(--panel-bg-elevated);
+	padding: 2px var(--space-1);
+	border-radius: var(--radius-sm);
+	color: var(--accent);
+}
+
+.shell-md-modal__body table {
+	border-collapse: collapse;
+	width: 100%;
+	margin-bottom: var(--space-3);
+}
+
+.shell-md-modal__body th,
+.shell-md-modal__body td {
+	border: 1px solid var(--panel-border);
+	padding: var(--space-2) var(--space-3);
+	text-align: left;
+}
+
+.shell-md-modal__body th {
+	background: var(--panel-bg-elevated);
+	color: var(--text-secondary);
+}
+
+.shell-md-modal__body ul,
+.shell-md-modal__body ol {
+	margin-bottom: var(--space-3);
+	padding-left: var(--space-5);
+}
+
+.shell-md-modal__body blockquote {
+	border-left: 3px solid var(--panel-border-strong);
+	margin: 0 0 var(--space-3) 0;
+	padding-left: var(--space-4);
+	color: var(--text-muted);
+}
+
+.shell-md-modal__body a {
+	color: var(--accent);
+	text-decoration: underline;
+}
+
+.shell-md-modal__body del {
+	color: var(--text-muted);
+}

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -1258,3 +1258,20 @@ select {
 .shell-md-modal__body del {
 	color: var(--text-muted);
 }
+
+.shell-md-modal__retry {
+	margin-top: var(--space-2);
+	padding: var(--space-1) var(--space-3);
+	background: transparent;
+	border: 1px solid var(--panel-border);
+	border-radius: var(--radius-sm);
+	color: var(--text-secondary);
+	cursor: pointer;
+	font-family: var(--font-ui);
+	font-size: 0.875rem;
+}
+
+.shell-md-modal__retry:hover {
+	border-color: var(--panel-border-strong);
+	color: var(--text-primary);
+}

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -1174,12 +1174,11 @@ select {
 
 .shell-md-modal__scroll {
 	flex: 1;
-	overflow: hidden;
+	overflow-y: auto;
 	min-height: 0;
 }
 
 .shell-md-modal__body {
-	height: 100%;
 	padding: var(--space-4) var(--space-6);
 	color: var(--text-primary);
 	line-height: 1.6;

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -1175,9 +1175,11 @@ select {
 .shell-md-modal__scroll {
 	flex: 1;
 	overflow: hidden;
+	min-height: 0;
 }
 
 .shell-md-modal__body {
+	height: 100%;
 	padding: var(--space-4) var(--space-6);
 	color: var(--text-primary);
 	line-height: 1.6;

--- a/src/features/viewer/FileList.tsx
+++ b/src/features/viewer/FileList.tsx
@@ -109,6 +109,10 @@ export function FileList({
 			});
 	}, [worktreePath, scopeRoots]);
 
+	useEffect(() => {
+		setPreviewPath(null);
+	}, [worktreePath]);
+
 	if (gitSummaryError) {
 		return (
 			<div className="shell-rail__message">

--- a/src/features/viewer/FileList.tsx
+++ b/src/features/viewer/FileList.tsx
@@ -1,9 +1,12 @@
+// src/features/viewer/FileList.tsx
 import { useEffect, useState } from "react";
+import * as ContextMenu from "@radix-ui/react-context-menu";
 import { files } from "../../lib/desktop-client";
 import {
 	buildScopedFileTree,
 	type ScopedFileTreeNode,
 } from "./build-scoped-file-tree";
+import { MarkdownPreviewModal } from "./MarkdownPreviewModal";
 
 type FileListProps = {
 	worktreePath: string;
@@ -18,13 +21,15 @@ function TreeNode({
 	node,
 	selectedFile,
 	onSelect,
+	onPreview,
 }: {
 	node: ScopedFileTreeNode;
 	selectedFile: string | null;
 	onSelect: (relativePath: string) => void;
+	onPreview: (relativePath: string) => void;
 }) {
 	if (node.type === "file") {
-		return (
+		const button = (
 			<button
 				type="button"
 				className="shell-list__item shell-list__item--tree"
@@ -34,6 +39,26 @@ function TreeNode({
 				{node.name}
 			</button>
 		);
+
+		if (node.name.endsWith(".md")) {
+			return (
+				<ContextMenu.Root>
+					<ContextMenu.Trigger asChild>{button}</ContextMenu.Trigger>
+					<ContextMenu.Portal>
+						<ContextMenu.Content className="shell-toolbar-menu">
+							<ContextMenu.Item
+								className="shell-toolbar-menu__item"
+								onSelect={() => onPreview(node.path)}
+							>
+								Preview
+							</ContextMenu.Item>
+						</ContextMenu.Content>
+					</ContextMenu.Portal>
+				</ContextMenu.Root>
+			);
+		}
+
+		return button;
 	}
 
 	return (
@@ -46,6 +71,7 @@ function TreeNode({
 						node={child}
 						selectedFile={selectedFile}
 						onSelect={onSelect}
+						onPreview={onPreview}
 					/>
 				))}
 			</div>
@@ -64,6 +90,7 @@ export function FileList({
 	const [fileList, setFileList] = useState<string[]>([]);
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+	const [previewPath, setPreviewPath] = useState<string | null>(null);
 
 	useEffect(() => {
 		if (scopeRoots.length === 0) return;
@@ -126,9 +153,18 @@ export function FileList({
 						node={node}
 						selectedFile={selectedFile}
 						onSelect={onSelect}
+						onPreview={setPreviewPath}
 					/>
 				))}
 			</div>
+			{previewPath !== null && (
+				<MarkdownPreviewModal
+					worktreePath={worktreePath}
+					relativePath={previewPath}
+					open={true}
+					onClose={() => setPreviewPath(null)}
+				/>
+			)}
 		</>
 	);
 }

--- a/src/features/viewer/FileViewer.tsx
+++ b/src/features/viewer/FileViewer.tsx
@@ -24,6 +24,10 @@ export function FileViewer({ worktreePath, relativePath }: FileViewerProps) {
 	}, [fileView]);
 
 	useEffect(() => {
+		setPreviewOpen(false);
+	}, [worktreePath, relativePath]);
+
+	useEffect(() => {
 		if (!worktreePath || !relativePath) return;
 		setLoading(true);
 		setMessage(null);

--- a/src/features/viewer/FileViewer.tsx
+++ b/src/features/viewer/FileViewer.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import Editor from "@monaco-editor/react";
+import type { OnMount } from "@monaco-editor/react";
 import * as ContextMenu from "@radix-ui/react-context-menu";
 import type { FileView } from "../../../shared/models/file-view";
 import { files } from "../../lib/desktop-client";
@@ -18,6 +19,8 @@ export function FileViewer({ worktreePath, relativePath }: FileViewerProps) {
 	const [reloadToken, setReloadToken] = useState(0);
 	const latestFileViewRef = useRef<FileView | null>(null);
 	const [previewOpen, setPreviewOpen] = useState(false);
+	const editorRef = useRef<Parameters<OnMount>[0] | null>(null);
+	const previewActionRef = useRef<{ dispose(): void } | null>(null);
 
 	useEffect(() => {
 		latestFileViewRef.current = fileView;
@@ -26,6 +29,25 @@ export function FileViewer({ worktreePath, relativePath }: FileViewerProps) {
 	useEffect(() => {
 		setPreviewOpen(false);
 	}, [worktreePath, relativePath]);
+
+	useEffect(() => {
+		if (!editorRef.current) return;
+		previewActionRef.current?.dispose();
+		previewActionRef.current = null;
+		if (relativePath.endsWith(".md")) {
+			previewActionRef.current = editorRef.current.addAction({
+				id: "markdown-preview",
+				label: "Preview",
+				contextMenuGroupId: "navigation",
+				contextMenuOrder: 1.5,
+				run: () => setPreviewOpen(true),
+			});
+		}
+		return () => {
+			previewActionRef.current?.dispose();
+			previewActionRef.current = null;
+		};
+	}, [relativePath]); // eslint-disable-line react-hooks/exhaustive-deps
 
 	useEffect(() => {
 		if (!worktreePath || !relativePath) return;
@@ -97,6 +119,18 @@ export function FileViewer({ worktreePath, relativePath }: FileViewerProps) {
 				theme="vs-dark"
 				value={fileView.content}
 				options={{ readOnly: true, fontSize: 12, minimap: { enabled: false } }}
+				onMount={(editor) => {
+					editorRef.current = editor;
+					if (relativePath.endsWith(".md")) {
+						previewActionRef.current = editor.addAction({
+							id: "markdown-preview",
+							label: "Preview",
+							contextMenuGroupId: "navigation",
+							contextMenuOrder: 1.5,
+							run: () => setPreviewOpen(true),
+						});
+					}
+				}}
 			/>
 			{previewOpen && (
 				<MarkdownPreviewModal

--- a/src/features/viewer/FileViewer.tsx
+++ b/src/features/viewer/FileViewer.tsx
@@ -1,7 +1,9 @@
 import { useState, useEffect, useRef } from "react";
 import Editor from "@monaco-editor/react";
+import * as ContextMenu from "@radix-ui/react-context-menu";
 import type { FileView } from "../../../shared/models/file-view";
 import { files } from "../../lib/desktop-client";
+import { MarkdownPreviewModal } from "./MarkdownPreviewModal";
 
 interface FileViewerProps {
 	worktreePath: string;
@@ -15,6 +17,7 @@ export function FileViewer({ worktreePath, relativePath }: FileViewerProps) {
 	const [message, setMessage] = useState<string | null>(null);
 	const [reloadToken, setReloadToken] = useState(0);
 	const latestFileViewRef = useRef<FileView | null>(null);
+	const [previewOpen, setPreviewOpen] = useState(false);
 
 	useEffect(() => {
 		latestFileViewRef.current = fileView;
@@ -53,9 +56,29 @@ export function FileViewer({ worktreePath, relativePath }: FileViewerProps) {
 
 	return (
 		<div className="shell-viewer">
-			<div className="shell-viewer__header">
-				<div className="shell-viewer__title">{fileView.path}</div>
-			</div>
+			{relativePath.endsWith(".md") ? (
+				<ContextMenu.Root>
+					<ContextMenu.Trigger asChild>
+						<div className="shell-viewer__header">
+							<div className="shell-viewer__title">{fileView.path}</div>
+						</div>
+					</ContextMenu.Trigger>
+					<ContextMenu.Portal>
+						<ContextMenu.Content className="shell-toolbar-menu">
+							<ContextMenu.Item
+								className="shell-toolbar-menu__item"
+								onSelect={() => setPreviewOpen(true)}
+							>
+								Preview
+							</ContextMenu.Item>
+						</ContextMenu.Content>
+					</ContextMenu.Portal>
+				</ContextMenu.Root>
+			) : (
+				<div className="shell-viewer__header">
+					<div className="shell-viewer__title">{fileView.path}</div>
+				</div>
+			)}
 			{message && (
 				<p className={stale ? "shell-inline-warning" : "shell-error"}>{message}</p>
 			)}
@@ -71,6 +94,14 @@ export function FileViewer({ worktreePath, relativePath }: FileViewerProps) {
 				value={fileView.content}
 				options={{ readOnly: true, fontSize: 12, minimap: { enabled: false } }}
 			/>
+			{previewOpen && (
+				<MarkdownPreviewModal
+					worktreePath={worktreePath}
+					relativePath={relativePath}
+					open={true}
+					onClose={() => setPreviewOpen(false)}
+				/>
+			)}
 		</div>
 	);
 }

--- a/src/features/viewer/MarkdownPreviewModal.tsx
+++ b/src/features/viewer/MarkdownPreviewModal.tsx
@@ -51,7 +51,7 @@ export function MarkdownPreviewModal({
 						<Dialog.Title className="shell-md-modal__title">
 							{relativePath}
 						</Dialog.Title>
-						<Dialog.Close className="shell-md-modal__close">✕</Dialog.Close>
+						<Dialog.Close className="shell-md-modal__close" aria-label="Close">✕</Dialog.Close>
 					</div>
 					{loading && (
 						<p className="shell-empty-state">Loading {relativePath}…</p>
@@ -60,6 +60,7 @@ export function MarkdownPreviewModal({
 						<>
 							<p className="shell-error">{error}</p>
 							<button
+								className="shell-md-modal__retry"
 								type="button"
 								onClick={() => setReloadToken((x) => x + 1)}
 							>

--- a/src/features/viewer/MarkdownPreviewModal.tsx
+++ b/src/features/viewer/MarkdownPreviewModal.tsx
@@ -1,0 +1,89 @@
+import { useState, useEffect } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import * as ScrollArea from "@radix-ui/react-scroll-area";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeHighlight from "rehype-highlight";
+import "highlight.js/styles/github-dark.css";
+import { files } from "../../lib/desktop-client";
+
+interface Props {
+	worktreePath: string;
+	relativePath: string;
+	open: boolean;
+	onClose: () => void;
+}
+
+export function MarkdownPreviewModal({
+	worktreePath,
+	relativePath,
+	open,
+	onClose,
+}: Props) {
+	const [content, setContent] = useState<string | null>(null);
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [reloadToken, setReloadToken] = useState(0);
+
+	useEffect(() => {
+		if (!open) return;
+		setLoading(true);
+		setError(null);
+		setContent(null);
+		files
+			.read(worktreePath, relativePath)
+			.then((view) => {
+				setContent(view.content);
+				setLoading(false);
+			})
+			.catch(() => {
+				setError("Couldn't load file contents.");
+				setLoading(false);
+			});
+	}, [open, worktreePath, relativePath, reloadToken]);
+
+	return (
+		<Dialog.Root open={open} onOpenChange={(isOpen) => { if (!isOpen) onClose(); }}>
+			<Dialog.Portal>
+				<Dialog.Overlay className="shell-md-overlay" />
+				<Dialog.Content className="shell-md-modal" aria-describedby={undefined}>
+					<div className="shell-md-modal__header">
+						<Dialog.Title className="shell-md-modal__title">
+							{relativePath}
+						</Dialog.Title>
+						<Dialog.Close className="shell-md-modal__close">✕</Dialog.Close>
+					</div>
+					{loading && (
+						<p className="shell-empty-state">Loading {relativePath}…</p>
+					)}
+					{error && (
+						<>
+							<p className="shell-error">{error}</p>
+							<button
+								type="button"
+								onClick={() => setReloadToken((x) => x + 1)}
+							>
+								Retry
+							</button>
+						</>
+					)}
+					{content !== null && (
+						<ScrollArea.Root className="shell-md-modal__scroll">
+							<ScrollArea.Viewport className="shell-md-modal__body">
+								<ReactMarkdown
+									remarkPlugins={[remarkGfm]}
+									rehypePlugins={[rehypeHighlight]}
+								>
+									{content}
+								</ReactMarkdown>
+							</ScrollArea.Viewport>
+							<ScrollArea.Scrollbar orientation="vertical">
+								<ScrollArea.Thumb />
+							</ScrollArea.Scrollbar>
+						</ScrollArea.Root>
+					)}
+				</Dialog.Content>
+			</Dialog.Portal>
+		</Dialog.Root>
+	);
+}

--- a/src/features/viewer/MarkdownPreviewModal.tsx
+++ b/src/features/viewer/MarkdownPreviewModal.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
-import * as ScrollArea from "@radix-ui/react-scroll-area";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
@@ -69,19 +68,16 @@ export function MarkdownPreviewModal({
 						</>
 					)}
 					{content !== null && (
-						<ScrollArea.Root className="shell-md-modal__scroll">
-							<ScrollArea.Viewport className="shell-md-modal__body">
+						<div className="shell-md-modal__scroll">
+							<div className="shell-md-modal__body">
 								<ReactMarkdown
 									remarkPlugins={[remarkGfm]}
 									rehypePlugins={[rehypeHighlight]}
 								>
 									{content}
 								</ReactMarkdown>
-							</ScrollArea.Viewport>
-							<ScrollArea.Scrollbar orientation="vertical">
-								<ScrollArea.Thumb />
-							</ScrollArea.Scrollbar>
-						</ScrollArea.Root>
+							</div>
+						</div>
 					)}
 				</Dialog.Content>
 			</Dialog.Portal>

--- a/tests/e2e/cumulative-flow.phase-6.test.ts
+++ b/tests/e2e/cumulative-flow.phase-6.test.ts
@@ -355,4 +355,39 @@ test.describe.serial("Cumulative flow — Phase 6", () => {
 		await expect(page.getByText(/showing last successful result/i)).toBeVisible();
 		await expect(page.getByRole("button", { name: /src\/index\.ts/i })).toBeVisible();
 	});
+
+	test("right-clicking a .md file shows Preview and opens the markdown modal", async () => {
+		await ensureWorkspaceLoaded();
+
+		// Navigate to feature-a — it has a dirty NOTES.md so scopeRoots is non-empty
+		await page
+			.getByRole("navigation", { name: "Worktree sessions" })
+			.getByRole("button", { name: /feature-a/i })
+			.click();
+
+		// Switch to Files tab in the review rail
+		await page.getByRole("tab", { name: "Files" }).click({ force: true });
+
+		// Wait for NOTES.md to appear (scopeRoots includes "." for root-level dirty files)
+		const notesButton = page.getByRole("button", { name: "NOTES.md" });
+		await expect(notesButton).toBeVisible({ timeout: 10_000 });
+
+		// Right-click to open context menu
+		await notesButton.click({ button: "right" });
+		await expect(page.getByRole("menuitem", { name: "Preview" })).toBeVisible();
+
+		// Click Preview
+		await page.getByRole("menuitem", { name: "Preview" }).click();
+
+		// Modal should appear with rendered heading from "# Preview Test"
+		await expect(
+			page.getByRole("heading", { name: "Preview Test" }),
+		).toBeVisible({ timeout: 10_000 });
+
+		// ESC should close the modal
+		await page.keyboard.press("Escape");
+		await expect(
+			page.getByRole("heading", { name: "Preview Test" }),
+		).not.toBeVisible();
+	});
 });

--- a/tests/e2e/cumulative-flow.phase-6.test.ts
+++ b/tests/e2e/cumulative-flow.phase-6.test.ts
@@ -390,4 +390,40 @@ test.describe.serial("Cumulative flow — Phase 6", () => {
 			page.getByRole("heading", { name: "Preview Test" }),
 		).not.toBeVisible();
 	});
+
+	test("right-clicking viewer panel header of a .md file shows Preview and opens the modal", async () => {
+		await ensureWorkspaceLoaded();
+
+		// Navigate to feature-a
+		await page
+			.getByRole("navigation", { name: "Worktree sessions" })
+			.getByRole("button", { name: /feature-a/i })
+			.click();
+
+		// Open Files tab and click NOTES.md to load it in the viewer
+		await page.getByRole("tab", { name: "Files" }).click({ force: true });
+		const notesButton = page.getByRole("button", { name: "NOTES.md" });
+		await expect(notesButton).toBeVisible({ timeout: 10_000 });
+		await notesButton.click();
+
+		// Wait for viewer header to show the file path
+		const viewerTitle = page.locator(".shell-viewer__title", { hasText: "NOTES.md" });
+		await expect(viewerTitle).toBeVisible({ timeout: 10_000 });
+
+		// Right-click the viewer header
+		await viewerTitle.click({ button: "right" });
+		await expect(page.getByRole("menuitem", { name: "Preview" })).toBeVisible();
+
+		// Click Preview — modal should open with "# Preview Test" heading
+		await page.getByRole("menuitem", { name: "Preview" }).click();
+		await expect(
+			page.getByRole("heading", { name: "Preview Test" }),
+		).toBeVisible({ timeout: 10_000 });
+
+		// ESC closes the modal
+		await page.keyboard.press("Escape");
+		await expect(
+			page.getByRole("heading", { name: "Preview Test" }),
+		).not.toBeVisible();
+	});
 });

--- a/tests/e2e/fixtures/create-test-repo.ts
+++ b/tests/e2e/fixtures/create-test-repo.ts
@@ -88,6 +88,11 @@ export function createTestRepo(): TestRepo {
 		join(worktreePath, "src", "new-file.ts"),
 		"export const added = true;\n",
 	);
+	// Add a dirty .md file so the Files tab has scope for the markdown preview E2E test
+	writeFileSync(
+		join(worktreePath, "NOTES.md"),
+		"# Preview Test\n\nThis file exists for E2E markdown preview coverage.\n",
+	);
 
 	return {
 		repoPath,

--- a/tests/unit/components/FileList.test.tsx
+++ b/tests/unit/components/FileList.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 
 vi.mock("../../../src/lib/desktop-client", () => ({
 	files: {
@@ -227,5 +227,41 @@ describe("FileList", () => {
 		expect(
 			await screen.findByText("Loading README.md…"),
 		).toBeInTheDocument();
+	});
+
+	it("closes the preview modal when worktreePath changes", async () => {
+		mockListScoped.mockResolvedValue(["README.md"]);
+		vi.mocked(files.read).mockReturnValue(new Promise(() => {}));
+
+		const { rerender } = render(
+			<FileList
+				worktreePath="/repo"
+				scopeRoots={["."]}
+				selectedFile={null}
+				onSelect={vi.fn()}
+			/>,
+		);
+
+		// Open the preview
+		const mdFile = await screen.findByRole("button", { name: "README.md" });
+		fireEvent.contextMenu(mdFile);
+		const previewItem = await screen.findByRole("menuitem", { name: "Preview" });
+		fireEvent.click(previewItem);
+		await screen.findByText("Loading README.md…");
+
+		// Simulate worktree change
+		rerender(
+			<FileList
+				worktreePath="/repo2"
+				scopeRoots={["."]}
+				selectedFile={null}
+				onSelect={vi.fn()}
+			/>,
+		);
+
+		// Modal should be gone
+		await waitFor(() => {
+			expect(screen.queryByText(/Loading README\.md/)).not.toBeInTheDocument();
+		});
 	});
 });

--- a/tests/unit/components/FileList.test.tsx
+++ b/tests/unit/components/FileList.test.tsx
@@ -163,4 +163,69 @@ describe("FileList", () => {
 			screen.queryByText("No nearby files for changed directories."),
 		).not.toBeInTheDocument();
 	});
+
+	it("shows context menu with Preview item when a .md file is right-clicked", async () => {
+		mockListScoped.mockResolvedValueOnce(["README.md", "src/index.ts"]);
+		vi.mocked(files.read).mockReturnValue(new Promise(() => {}));
+
+		render(
+			<FileList
+				worktreePath="/repo"
+				scopeRoots={["."]}
+				selectedFile={null}
+				onSelect={vi.fn()}
+			/>,
+		);
+
+		const mdFile = await screen.findByRole("button", { name: "README.md" });
+		fireEvent.contextMenu(mdFile);
+
+		expect(
+			await screen.findByRole("menuitem", { name: "Preview" }),
+		).toBeInTheDocument();
+	});
+
+	it("does not show a context menu when a non-.md file is right-clicked", async () => {
+		mockListScoped.mockResolvedValueOnce(["src/index.ts"]);
+
+		render(
+			<FileList
+				worktreePath="/repo"
+				scopeRoots={["src"]}
+				selectedFile={null}
+				onSelect={vi.fn()}
+			/>,
+		);
+
+		const tsFile = await screen.findByRole("button", { name: "index.ts" });
+		fireEvent.contextMenu(tsFile);
+
+		expect(
+			screen.queryByRole("menuitem", { name: "Preview" }),
+		).not.toBeInTheDocument();
+	});
+
+	it("opens the markdown preview modal when Preview is clicked", async () => {
+		mockListScoped.mockResolvedValueOnce(["README.md"]);
+		vi.mocked(files.read).mockReturnValue(new Promise(() => {}));
+
+		render(
+			<FileList
+				worktreePath="/repo"
+				scopeRoots={["."]}
+				selectedFile={null}
+				onSelect={vi.fn()}
+			/>,
+		);
+
+		const mdFile = await screen.findByRole("button", { name: "README.md" });
+		fireEvent.contextMenu(mdFile);
+
+		const previewItem = await screen.findByRole("menuitem", { name: "Preview" });
+		fireEvent.click(previewItem);
+
+		expect(
+			await screen.findByText("Loading README.md…"),
+		).toBeInTheDocument();
+	});
 });

--- a/tests/unit/components/FileViewer.test.tsx
+++ b/tests/unit/components/FileViewer.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import type { FileView } from "../../../shared/models/file-view";
 
 vi.mock("../../../src/lib/desktop-client", () => ({
@@ -114,5 +114,63 @@ describe("FileViewer", () => {
 		await waitFor(() => {
 			expect(screen.getByText(/showing last successful result/i)).toBeInTheDocument();
 		});
+	});
+
+	it("shows Preview context menu item when right-clicking header of a .md file", async () => {
+		mockRead
+			.mockResolvedValueOnce({
+				path: "README.md",
+				content: "# Hello",
+				language: "markdown",
+			})
+			.mockReturnValue(new Promise(() => {})); // preview modal fetch never resolves
+
+		render(<FileViewer worktreePath="/repo" relativePath="README.md" />);
+
+		const title = await screen.findByText("README.md");
+		fireEvent.contextMenu(title);
+
+		expect(
+			await screen.findByRole("menuitem", { name: "Preview" }),
+		).toBeInTheDocument();
+	});
+
+	it("does not show a context menu when right-clicking header of a non-.md file", async () => {
+		mockRead.mockResolvedValueOnce({
+			path: "src/index.ts",
+			content: "const x = 1;",
+			language: "typescript",
+		});
+
+		render(<FileViewer worktreePath="/repo" relativePath="src/index.ts" />);
+
+		const title = await screen.findByText("src/index.ts");
+		fireEvent.contextMenu(title);
+
+		expect(
+			screen.queryByRole("menuitem", { name: "Preview" }),
+		).not.toBeInTheDocument();
+	});
+
+	it("opens the markdown preview modal when Preview is clicked in FileViewer", async () => {
+		mockRead
+			.mockResolvedValueOnce({
+				path: "README.md",
+				content: "# Hello",
+				language: "markdown",
+			})
+			.mockReturnValue(new Promise(() => {})); // modal fetch never resolves
+
+		render(<FileViewer worktreePath="/repo" relativePath="README.md" />);
+
+		const title = await screen.findByText("README.md");
+		fireEvent.contextMenu(title);
+
+		const previewItem = await screen.findByRole("menuitem", { name: "Preview" });
+		fireEvent.click(previewItem);
+
+		expect(
+			await screen.findByText("Loading README.md…"),
+		).toBeInTheDocument();
 	});
 });

--- a/tests/unit/components/FileViewer.test.tsx
+++ b/tests/unit/components/FileViewer.test.tsx
@@ -173,4 +173,31 @@ describe("FileViewer", () => {
 			await screen.findByText("Loading README.md…"),
 		).toBeInTheDocument();
 	});
+
+	it("closes preview modal when relativePath changes", async () => {
+		mockRead
+			.mockResolvedValueOnce({
+				path: "README.md",
+				content: "# Hello",
+				language: "markdown",
+			})
+			.mockReturnValue(new Promise(() => {})); // modal fetch + subsequent viewer fetches never resolve
+
+		const { rerender } = render(
+			<FileViewer worktreePath="/repo" relativePath="README.md" />,
+		);
+
+		// Open the preview modal
+		const title = await screen.findByText("README.md");
+		fireEvent.contextMenu(title);
+		fireEvent.click(await screen.findByRole("menuitem", { name: "Preview" }));
+		expect(await screen.findByText("Loading README.md…")).toBeInTheDocument();
+
+		// Navigate to a different file — modal should close
+		rerender(<FileViewer worktreePath="/repo" relativePath="src/index.ts" />);
+
+		await waitFor(() => {
+			expect(screen.queryByText("Loading README.md…")).not.toBeInTheDocument();
+		});
+	});
 });

--- a/tests/unit/components/MarkdownPreviewModal.test.tsx
+++ b/tests/unit/components/MarkdownPreviewModal.test.tsx
@@ -197,7 +197,7 @@ describe("MarkdownPreviewModal", () => {
 		);
 
 		await screen.findByRole("heading", { name: "Hello" });
-		fireEvent.click(screen.getByRole("button", { name: "✕" }));
+		fireEvent.click(screen.getByRole("button", { name: "Close" }));
 		expect(onClose).toHaveBeenCalled();
 	});
 });

--- a/tests/unit/components/MarkdownPreviewModal.test.tsx
+++ b/tests/unit/components/MarkdownPreviewModal.test.tsx
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import type { FileView } from "../../../shared/models/file-view";
+
+vi.mock("../../../src/lib/desktop-client", () => ({
+	files: {
+		read: vi.fn(),
+	},
+	workspace: {
+		readRestoreState: vi.fn().mockResolvedValue({
+			version: 1,
+			restorePreference: "prompt",
+			snapshot: null,
+		}),
+		writeRestoreState: vi.fn(),
+	},
+}));
+
+import { MarkdownPreviewModal } from "../../../src/features/viewer/MarkdownPreviewModal";
+import { files } from "../../../src/lib/desktop-client";
+
+const mockRead = vi.mocked(files.read);
+
+const fakeView: FileView = {
+	path: "README.md",
+	content: "# Hello\n\nSome text.\n",
+	language: "markdown",
+};
+
+describe("MarkdownPreviewModal", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("shows loading state while fetching", () => {
+		mockRead.mockReturnValue(new Promise(() => {}));
+
+		render(
+			<MarkdownPreviewModal
+				worktreePath="/repo"
+				relativePath="README.md"
+				open={true}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		expect(screen.getByText("Loading README.md…")).toBeInTheDocument();
+	});
+
+	it("shows file path in header", async () => {
+		mockRead.mockResolvedValueOnce(fakeView);
+
+		render(
+			<MarkdownPreviewModal
+				worktreePath="/repo"
+				relativePath="README.md"
+				open={true}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		// Dialog.Title renders relativePath; wait for open state to settle
+		expect(await screen.findByText("README.md")).toBeInTheDocument();
+	});
+
+	it("renders a markdown heading", async () => {
+		mockRead.mockResolvedValueOnce(fakeView);
+
+		render(
+			<MarkdownPreviewModal
+				worktreePath="/repo"
+				relativePath="README.md"
+				open={true}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		expect(
+			await screen.findByRole("heading", { name: "Hello" }),
+		).toBeInTheDocument();
+	});
+
+	it("renders a GFM table", async () => {
+		mockRead.mockResolvedValueOnce({
+			...fakeView,
+			content: "| A | B |\n|---|---|\n| 1 | 2 |\n",
+		});
+
+		render(
+			<MarkdownPreviewModal
+				worktreePath="/repo"
+				relativePath="README.md"
+				open={true}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		expect(await screen.findByRole("table")).toBeInTheDocument();
+		expect(screen.getByText("A")).toBeInTheDocument();
+		expect(screen.getByText("B")).toBeInTheDocument();
+	});
+
+	it("renders GFM task list checkboxes", async () => {
+		mockRead.mockResolvedValueOnce({
+			...fakeView,
+			content: "- [x] Done\n- [ ] Todo\n",
+		});
+
+		render(
+			<MarkdownPreviewModal
+				worktreePath="/repo"
+				relativePath="README.md"
+				open={true}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		const checkboxes = await screen.findAllByRole("checkbox");
+		expect(checkboxes).toHaveLength(2);
+		expect(checkboxes[0]).toBeChecked();
+		expect(checkboxes[1]).not.toBeChecked();
+	});
+
+	it("renders a fenced code block with a language class", async () => {
+		mockRead.mockResolvedValueOnce({
+			...fakeView,
+			content: "```ts\nconst x = 1;\n```\n",
+		});
+
+		render(
+			<MarkdownPreviewModal
+				worktreePath="/repo"
+				relativePath="README.md"
+				open={true}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		// rehype-highlight adds language-ts class to the <code> element
+		await waitFor(() => {
+			expect(document.querySelector("code.language-ts")).not.toBeNull();
+		});
+	});
+
+	it("shows error and Retry button when fetch fails", async () => {
+		mockRead.mockRejectedValueOnce(new Error("not found"));
+
+		render(
+			<MarkdownPreviewModal
+				worktreePath="/repo"
+				relativePath="README.md"
+				open={true}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		expect(
+			await screen.findByText("Couldn't load file contents."),
+		).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+	});
+
+	it("re-fetches when Retry is clicked", async () => {
+		mockRead
+			.mockRejectedValueOnce(new Error("fail"))
+			.mockResolvedValueOnce(fakeView);
+
+		render(
+			<MarkdownPreviewModal
+				worktreePath="/repo"
+				relativePath="README.md"
+				open={true}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		await screen.findByText("Couldn't load file contents.");
+		fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+		expect(
+			await screen.findByRole("heading", { name: "Hello" }),
+		).toBeInTheDocument();
+		expect(mockRead).toHaveBeenCalledTimes(2);
+	});
+
+	it("calls onClose when the close button is clicked", async () => {
+		mockRead.mockResolvedValueOnce(fakeView);
+		const onClose = vi.fn();
+
+		render(
+			<MarkdownPreviewModal
+				worktreePath="/repo"
+				relativePath="README.md"
+				open={true}
+				onClose={onClose}
+			/>,
+		);
+
+		await screen.findByRole("heading", { name: "Hello" });
+		fireEvent.click(screen.getByRole("button", { name: "✕" }));
+		expect(onClose).toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary

- Right-click any `.md` file in the file list → **Preview** context menu opens a modal with full GitHub-Flavored Markdown rendering (tables, task lists, syntax-highlighted code blocks)
- Right-click the viewer panel header **or inside the Monaco editor** on a `.md` file → same **Preview** action appears
- Modal content scrolls correctly for long documents

## Changes

- `MarkdownPreviewModal.tsx` — new Radix Dialog modal; fetches file via `files.read`, renders with `react-markdown` + `remark-gfm` + `rehype-highlight`; loading/error/retry states
- `FileList.tsx` — Radix ContextMenu on `.md` tree nodes; resets on worktree change
- `FileViewer.tsx` — Radix ContextMenu on viewer header + Monaco `editor.addAction()` for right-click inside the editor canvas; `previewOpen` state resets on file change
- `shell.css` — modal overlay, layout, markdown content styles; native `overflow-y: auto` scroll

## Test Plan

- [ ] Unit tests: `MarkdownPreviewModal` (9 tests), `FileList` (11 tests), `FileViewer` (9 tests) — all passing
- [ ] E2E: `cumulative-flow.phase-6` — right-click `.md` in FileList → Preview → modal → ESC closes; right-click viewer header → same flow
- [ ] Manual: open a long `.md` file, verify modal scrolls; open a `.md` file in viewer, right-click inside Monaco editor, verify "Preview" appears alongside Copy/Command Palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)