### PR TITLE
feat: dark/light mode (follows macOS system appearance)

### DIFF
--- a/docs/superpowers/specs/2026-04-09-dark-light-mode-design.md
+++ b/docs/superpowers/specs/2026-04-09-dark-light-mode-design.md
@@ -1,0 +1,143 @@
+# Dark / Light Mode — Design Spec
+
+**Date:** 2026-04-09
+**Status:** Approved
+
+---
+
+## Summary
+
+Add dark/light theme support to ai-14all. The app currently ships dark-only. This feature makes it respond to the macOS system appearance preference, with the architecture designed so a manual in-app toggle can be added later with minimal effort.
+
+---
+
+## Goals
+
+- App follows the macOS system appearance (light/dark) automatically.
+- Switching the system preference updates the app in real time, no restart needed.
+- Monaco editor (FileViewer, DiffViewer) switches theme in sync.
+- A future manual toggle requires only: calling `setTheme('light' | 'dark' | 'system')` and adding a UI button. No structural changes.
+
+## Non-Goals
+
+- No in-app toggle UI for this iteration.
+- No persisted preference for this iteration (localStorage added when toggle ships).
+- No custom Monaco theme — use built-in `vs` / `vs-dark`.
+
+---
+
+## Light Theme Palette
+
+Classic IDE Light aesthetic — white/light-gray backgrounds, blue accent (VS Code-style).
+
+| Variable | Light value | Dark value (existing) |
+|---|---|---|
+| `--app-bg` | `#f0f2f5` | `#0b1116` |
+| `--panel-bg` | `#ffffff` | `#111a21` |
+| `--panel-bg-elevated` | `#f5f7f9` | `#16232c` |
+| `--panel-border` | `#d0d7e0` | `#24313d` |
+| `--panel-border-strong` | `#a8b8cc` | `#345767` |
+| `--text-primary` | `#1e2530` | `#eef7fa` |
+| `--text-secondary` | `#4a5a70` | `#8fa4b1` |
+| `--text-muted` | `#7a8a9a` | `#6f8593` |
+| `--accent` | `#1a7fc1` | `#67d4b0` |
+| `--accent-strong` | `#ddeeff` | `#15383d` |
+| `--pane-border-sessions` | `rgba(30, 120, 220, 0.4)` | `rgba(79, 179, 255, 0.5)` |
+| `--pane-border-session-info` | `rgba(180, 120, 30, 0.4)` | `rgba(246, 169, 74, 0.5)` |
+| `--pane-border-terminal` | `rgba(30, 160, 100, 0.4)` | `rgba(67, 211, 158, 0.5)` |
+| `--pane-border-review` | `rgba(200, 60, 80, 0.4)` | `rgba(243, 107, 138, 0.5)` |
+| `--warning` | `#b07800` | `#f0c37a` |
+| `--danger` | `#c0404a` | `#d98c8c` |
+
+`body` background in light mode: `radial-gradient(circle at top, #e8edf4 0%, #f0f2f5 55%)` (mirrors the existing dark radial gradient).
+
+---
+
+## Architecture
+
+### CSS Layer — `src/app/shell.css`
+
+The existing `:root` block remains as-is (dark theme defaults). A new `[data-theme="light"]` block overrides all color variables and the `body` background. No media query — the attribute is set by JS so a future toggle can override it.
+
+```css
+[data-theme="light"] {
+  --app-bg: #f0f2f5;
+  /* ... all variables ... */
+}
+
+[data-theme="light"] body {
+  background: radial-gradient(circle at top, #e8edf4 0%, #f0f2f5 55%);
+}
+```
+
+### Theme Hook — `src/lib/useTheme.ts`
+
+A small hook that:
+1. Reads `window.matchMedia('(prefers-color-scheme: light)')` on mount.
+2. Sets `document.documentElement.setAttribute('data-theme', 'light' | 'dark')`.
+3. Subscribes to `matchMedia` `change` events to update reactively when the system preference changes.
+4. Returns `{ resolvedTheme: 'light' | 'dark', setTheme }`.
+
+`setTheme(mode: 'light' | 'dark' | 'system')` is wired in the hook but the app only uses `'system'` for now. When a toggle UI ships, it calls `setTheme` and the rest works automatically.
+
+```ts
+export type ThemeMode = 'light' | 'dark' | 'system';
+export type ResolvedTheme = 'light' | 'dark';
+
+export function useTheme(): {
+  resolvedTheme: ResolvedTheme;
+  setTheme: (mode: ThemeMode) => void;
+}
+```
+
+State is kept in React local state. Persistence (localStorage) is added alongside the toggle UI — one line in `setTheme`.
+
+### App Integration — `src/app/App.tsx`
+
+`useTheme()` is called once at the root of `App`. `resolvedTheme` is passed as a prop to the two Monaco consumers: `FileViewer` and `DiffViewer`. No context is needed — both are rendered directly in `App`.
+
+### Monaco Integration — `FileViewer.tsx` + `DiffViewer.tsx`
+
+Both files have `theme="vs-dark"` hardcoded on the Monaco `Editor` / `DiffEditor`. This becomes:
+
+```tsx
+theme={resolvedTheme === 'light' ? 'vs' : 'vs-dark'}
+```
+
+`vs` is Monaco's built-in light theme, `vs-dark` is its built-in dark theme. No custom theme registration needed.
+
+---
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `src/app/shell.css` | Add `[data-theme="light"]` variable overrides + light body background |
+| `src/lib/useTheme.ts` | New hook (system preference → DOM attribute) |
+| `src/app/App.tsx` | Call `useTheme()`, pass `resolvedTheme` to FileViewer + DiffViewer |
+| `src/features/viewer/FileViewer.tsx` | Accept `resolvedTheme` prop, pass to Monaco `Editor` |
+| `src/features/viewer/DiffViewer.tsx` | Accept `resolvedTheme` prop, pass to Monaco `DiffEditor` |
+
+---
+
+## Future Toggle (not in scope now)
+
+When ready, adding the toggle requires:
+1. A UI button that calls `setTheme('light' | 'dark' | 'system')`.
+2. One line in `useTheme` to persist to `localStorage`.
+3. One line on mount to read from `localStorage` before falling back to system.
+
+No structural changes to CSS, hook signature, or App wiring.
+
+---
+
+## Testing
+
+**Unit tests:**
+- `useTheme` hook: mock `matchMedia`, assert correct `data-theme` attribute is set on mount and on `change` event.
+- Verify `setTheme('light')` overrides system preference; `setTheme('system')` reverts to matchMedia result.
+
+**Manual / E2E:**
+- Switch macOS appearance in System Settings → app updates without reload.
+- FileViewer and DiffViewer Monaco editors switch theme in sync.
+- No flash of wrong theme on cold start.

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -55,6 +55,7 @@ import { CommitList } from "../features/git/CommitList";
 import { CommitDiffStack } from "../features/git/CommitDiffStack";
 import type { GitCommitHistory, GitCommitDetail } from "../../shared/models/git-commit-review";
 import { git, workspace, repository as repositoryClient } from "../lib/desktop-client";
+import { useTheme } from "../lib/useTheme";
 import { describeRepositoryLoadError } from "../features/repository/describe-repository-load-error";
 
 type StartupMode = "loading" | "prompt" | "ready";
@@ -68,6 +69,7 @@ function normalizeTerminalTitle(title: string): string | null {
 }
 
 export function App() {
+	const { resolvedTheme } = useTheme();
 	const [reviewRailWidth, setReviewRailWidth] = useState(320);
 	const [reviewPanelHeight, setReviewPanelHeight] = useState(280);
 	const [reviewPanelCollapsed, setReviewPanelCollapsed] = useState(false);
@@ -2047,6 +2049,7 @@ export function App() {
 										<FileViewer
 											worktreePath={activeWorktree.path}
 											relativePath={activeSession.selectedFilePath}
+											resolvedTheme={resolvedTheme}
 										/>
 									) : activeSession?.reviewMode === "changes" && diffState.data ? (
 										<DiffViewer
@@ -2054,6 +2057,7 @@ export function App() {
 											content={diffState.data.content}
 											originalContent={diffState.data.originalContent}
 											modifiedContent={diffState.data.modifiedContent}
+											resolvedTheme={resolvedTheme}
 										/>
 									) : (
 										<p className="shell-empty-state">

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2043,6 +2043,7 @@ export function App() {
 											key={commitDetailState.data.sha}
 											detail={commitDetailState.data}
 											focusedPath={activeSession.selectedCommitFilePath}
+											resolvedTheme={resolvedTheme}
 										/>
 									) : activeSession?.reviewMode === "files" &&
 									activeSession.selectedFilePath ? (

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -25,6 +25,7 @@
 	--pane-border-review: rgba(243, 107, 138, 0.5);
 	--warning: #f0c37a;
 	--danger: #d98c8c;
+	--sha-color: #a78bfa;
 	--font-ui:
 		"SF Mono",
 		"SFMono-Regular",
@@ -78,6 +79,7 @@
 	--pane-border-review: rgba(200, 60, 80, 0.4);
 	--warning: #b07800;
 	--danger: #c0404a;
+	--sha-color: #6d4cbc;
 	color: var(--text-primary);
 	background: var(--app-bg);
 }
@@ -85,6 +87,18 @@
 [data-theme="light"] body {
 	background: radial-gradient(circle at top, #e8edf4 0%, #f0f2f5 55%);
 	color: var(--text-primary);
+}
+
+[data-theme="light"] .shell-terminal-tab:hover,
+[data-theme="light"] .shell-review-tab:hover {
+	background: rgba(0, 0, 0, 0.04);
+}
+
+[data-theme="light"] .shell-terminal-tab[data-state="active"],
+[data-theme="light"] .shell-terminal-tab[data-state="active"]:hover,
+[data-theme="light"] .shell-review-tab[data-state="active"],
+[data-theme="light"] .shell-review-tab[data-state="active"]:hover {
+	box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.06);
 }
 
 * {
@@ -278,7 +292,7 @@ select {
 	white-space: pre-wrap;
 	word-break: break-word;
 	padding: 6px 8px;
-	background: rgba(10, 17, 21, 0.22);
+	background: var(--panel-bg-elevated);
 	border: 1px solid var(--panel-border);
 	border-radius: var(--radius-sm);
 	font-size: var(--font-size-body);
@@ -387,7 +401,7 @@ select {
 .shell-button {
 	padding: 8px 12px;
 	color: var(--text-primary);
-	background: #0f171d;
+	background: var(--panel-bg);
 	border: 1px solid var(--panel-border);
 	border-radius: var(--radius-sm);
 	cursor: pointer;
@@ -551,7 +565,7 @@ select {
 	padding: var(--space-3);
 	text-align: left;
 	color: var(--text-primary);
-	background: #0f171d;
+	background: var(--panel-bg);
 	border: 1px solid var(--panel-border);
 	border-radius: var(--radius-sm);
 	cursor: pointer;
@@ -669,13 +683,13 @@ select {
 
 .shell-terminal-tab[data-state="active"] {
 	color: var(--text-primary);
-	background: #4b5458;
+	background: var(--panel-bg-elevated);
 	border-color: var(--panel-border-strong);
 	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
 }
 
 .shell-terminal-tab[data-state="inactive"] {
-	color: #bcc7ce;
+	color: var(--text-secondary);
 }
 
 .shell-terminal-tab:hover {
@@ -683,7 +697,7 @@ select {
 }
 
 .shell-terminal-tab[data-state="active"]:hover {
-	background: #4b5458;
+	background: var(--panel-bg-elevated);
 }
 
 .shell-terminal-tabs__segments .shell-terminal-tabs__item + .shell-terminal-tabs__item {
@@ -718,7 +732,7 @@ select {
 	height: 100%;
 	min-height: 0;
 	padding: 0;
-	background: #0a1115;
+	background: var(--app-bg);
 }
 
 .shell-terminal-pane__viewport .xterm,
@@ -729,7 +743,7 @@ select {
 .shell-tooltip {
 	padding: 6px 10px;
 	color: var(--text-primary);
-	background: #0f171d;
+	background: var(--panel-bg);
 	border: 1px solid var(--panel-border);
 	border-radius: var(--radius-sm);
 }
@@ -767,7 +781,7 @@ select {
 	grid-template-columns: repeat(3, minmax(0, 1fr));
 	gap: 0;
 	padding: 2px;
-	background: #0f171d;
+	background: var(--panel-bg);
 	border: 1px solid var(--panel-border);
 	border-radius: 10px;
 }
@@ -787,13 +801,13 @@ select {
 
 .shell-review-tab[data-state="active"] {
 	color: var(--text-primary);
-	background: #4b5458;
+	background: var(--panel-bg-elevated);
 	border-color: var(--panel-border-strong);
 	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
 }
 
 .shell-review-tab[data-state="inactive"] {
-	color: #bcc7ce;
+	color: var(--text-secondary);
 }
 
 .shell-review-tab:hover {
@@ -801,7 +815,7 @@ select {
 }
 
 .shell-review-tab[data-state="active"]:hover {
-	background: #4b5458;
+	background: var(--panel-bg-elevated);
 }
 
 .shell-review-rail__scroll {
@@ -834,7 +848,7 @@ select {
 	padding: 8px 10px;
 	text-align: left;
 	color: var(--text-primary);
-	background: #0f171d;
+	background: var(--panel-bg);
 	border: 1px solid transparent;
 	border-radius: var(--radius-sm);
 	cursor: pointer;
@@ -1086,7 +1100,7 @@ select {
 .shell-terminal-panel__body {
 	min-height: 0;
 	overflow: hidden;
-	background: #0a1115;
+	background: var(--app-bg);
 	border-top: 1px solid var(--panel-border);
 }
 
@@ -1110,7 +1124,7 @@ select {
 	display: grid;
 	place-items: center;
 	padding: var(--space-4);
-	background: #0a1115;
+	background: var(--app-bg);
 }
 
 .shell-commit-list {
@@ -1207,7 +1221,7 @@ select {
 
 .shell-commit-list__sha {
 	min-width: 5.75ch;
-	color: #a78bfa;
+	color: var(--sha-color);
 }
 
 .shell-commit-list__item[data-row-kind="mergeTarget"] .shell-commit-list__sha {

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -61,6 +61,32 @@
 	--font-size-label: 15px;
 }
 
+[data-theme="light"] {
+	--app-bg: #f0f2f5;
+	--panel-bg: #ffffff;
+	--panel-bg-elevated: #f5f7f9;
+	--panel-border: #d0d7e0;
+	--panel-border-strong: #a8b8cc;
+	--text-primary: #1e2530;
+	--text-secondary: #4a5a70;
+	--text-muted: #7a8a9a;
+	--accent: #1a7fc1;
+	--accent-strong: #ddeeff;
+	--pane-border-sessions: rgba(30, 120, 220, 0.4);
+	--pane-border-session-info: rgba(180, 120, 30, 0.4);
+	--pane-border-terminal: rgba(30, 160, 100, 0.4);
+	--pane-border-review: rgba(200, 60, 80, 0.4);
+	--warning: #b07800;
+	--danger: #c0404a;
+	color: var(--text-primary);
+	background: var(--app-bg);
+}
+
+[data-theme="light"] body {
+	background: radial-gradient(circle at top, #e8edf4 0%, #f0f2f5 55%);
+	color: var(--text-primary);
+}
+
 * {
 	box-sizing: border-box;
 }

--- a/src/features/git/CommitDiffStack.tsx
+++ b/src/features/git/CommitDiffStack.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useRef, useState } from "react";
 import { DiffEditor } from "@monaco-editor/react";
 import type { GitCommitDetail } from "../../../shared/models/git-commit-review.js";
+import type { ResolvedTheme } from "../../lib/useTheme";
 
 type Props = {
 	detail: GitCommitDetail;
 	focusedPath: string | null;
+	resolvedTheme: ResolvedTheme;
 };
 
 const EXTENSION_TO_LANGUAGE: Record<string, string> = {
@@ -46,7 +48,7 @@ function editorHeightForFile(
 	return `${Math.max(lines * 20 + 32, 160)}px`;
 }
 
-export function CommitDiffStack({ detail, focusedPath }: Props) {
+export function CommitDiffStack({ detail, focusedPath, resolvedTheme }: Props) {
 	const [collapsedPaths, setCollapsedPaths] = useState<Set<string>>(new Set());
 	const sectionRefs = useRef<Record<string, HTMLElement | null>>({});
 	const singleFile = detail.files.length === 1;
@@ -117,7 +119,7 @@ export function CommitDiffStack({ detail, focusedPath }: Props) {
 												)
 									}
 									language={languageFromPath(file.path)}
-									theme="vs-dark"
+									theme={resolvedTheme === "light" ? "vs" : "vs-dark"}
 									original={file.originalContent}
 									modified={file.modifiedContent}
 									options={{

--- a/src/features/viewer/DiffViewer.tsx
+++ b/src/features/viewer/DiffViewer.tsx
@@ -1,4 +1,5 @@
 import { DiffEditor } from "@monaco-editor/react";
+import type { ResolvedTheme } from "../../lib/useTheme";
 
 const EXTENSION_TO_LANGUAGE: Record<string, string> = {
 	ts: "typescript",
@@ -25,6 +26,7 @@ type Props = {
 	content: string;
 	originalContent: string;
 	modifiedContent: string;
+	resolvedTheme: ResolvedTheme;
 };
 
 function languageFromPath(path: string): string | undefined {
@@ -36,6 +38,7 @@ export function DiffViewer({
 	path,
 	originalContent,
 	modifiedContent,
+	resolvedTheme,
 }: Props) {
 	return (
 		<div className="shell-viewer">
@@ -46,7 +49,7 @@ export function DiffViewer({
 			<DiffEditor
 				height="100%"
 				language={languageFromPath(path)}
-				theme="vs-dark"
+				theme={resolvedTheme === "light" ? "vs" : "vs-dark"}
 				original={originalContent}
 				modified={modifiedContent}
 				options={{

--- a/src/features/viewer/FileViewer.tsx
+++ b/src/features/viewer/FileViewer.tsx
@@ -4,14 +4,16 @@ import type { OnMount } from "@monaco-editor/react";
 import * as ContextMenu from "@radix-ui/react-context-menu";
 import type { FileView } from "../../../shared/models/file-view";
 import { files } from "../../lib/desktop-client";
+import type { ResolvedTheme } from "../../lib/useTheme";
 import { MarkdownPreviewModal } from "./MarkdownPreviewModal";
 
 interface FileViewerProps {
 	worktreePath: string;
 	relativePath: string;
+	resolvedTheme: ResolvedTheme;
 }
 
-export function FileViewer({ worktreePath, relativePath }: FileViewerProps) {
+export function FileViewer({ worktreePath, relativePath, resolvedTheme }: FileViewerProps) {
 	const [fileView, setFileView] = useState<FileView | null>(null);
 	const [loading, setLoading] = useState(false);
 	const [stale, setStale] = useState(false);
@@ -116,7 +118,7 @@ export function FileViewer({ worktreePath, relativePath }: FileViewerProps) {
 			<Editor
 				height="100%"
 				language={fileView.language}
-				theme="vs-dark"
+				theme={resolvedTheme === "light" ? "vs" : "vs-dark"}
 				value={fileView.content}
 				options={{ readOnly: true, fontSize: 12, minimap: { enabled: false } }}
 				onMount={(editor) => {

--- a/src/lib/useTheme.ts
+++ b/src/lib/useTheme.ts
@@ -1,0 +1,48 @@
+import { useState, useEffect } from "react";
+
+export type ThemeMode = "light" | "dark" | "system";
+export type ResolvedTheme = "light" | "dark";
+
+function getSystemTheme(): ResolvedTheme {
+	return window.matchMedia("(prefers-color-scheme: light)").matches
+		? "light"
+		: "dark";
+}
+
+function applyTheme(resolved: ResolvedTheme): void {
+	document.documentElement.setAttribute("data-theme", resolved);
+}
+
+export function useTheme(): {
+	resolvedTheme: ResolvedTheme;
+	setTheme: (mode: ThemeMode) => void;
+} {
+	const [mode, setMode] = useState<ThemeMode>("system");
+	const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>(() => {
+		const resolved = getSystemTheme();
+		applyTheme(resolved);
+		return resolved;
+	});
+
+	useEffect(() => {
+		const mql = window.matchMedia("(prefers-color-scheme: light)");
+
+		const resolved: ResolvedTheme =
+			mode === "system" ? (mql.matches ? "light" : "dark") : mode;
+		setResolvedTheme(resolved);
+		applyTheme(resolved);
+
+		if (mode !== "system") return;
+
+		const onChange = (e: Pick<MediaQueryListEvent, "matches">) => {
+			const next: ResolvedTheme = e.matches ? "light" : "dark";
+			setResolvedTheme(next);
+			applyTheme(next);
+		};
+
+		mql.addEventListener("change", onChange);
+		return () => mql.removeEventListener("change", onChange);
+	}, [mode]);
+
+	return { resolvedTheme, setTheme: setMode };
+}

--- a/src/lib/useTheme.ts
+++ b/src/lib/useTheme.ts
@@ -18,6 +18,8 @@ export function useTheme(): {
 	setTheme: (mode: ThemeMode) => void;
 } {
 	const [mode, setMode] = useState<ThemeMode>("system");
+	// Lazy initializer: apply theme synchronously during render to prevent
+	// a flash of unstyled content before the first useEffect fires.
 	const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>(() => {
 		const resolved = getSystemTheme();
 		applyTheme(resolved);

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,4 +1,5 @@
 import "@testing-library/jest-dom/vitest";
+import { vi } from "vitest";
 
 // Stub ResizeObserver for jsdom (not available in the test environment)
 global.ResizeObserver = class ResizeObserver {
@@ -6,3 +7,23 @@ global.ResizeObserver = class ResizeObserver {
 	unobserve() {}
 	disconnect() {}
 };
+
+// Mock window.matchMedia for useTheme hook (only in browser-like environments)
+if (typeof window !== "undefined") {
+	const listeners: Array<(e: Pick<MediaQueryListEvent, "matches">) => void> = [];
+	const mql = {
+		matches: false, // Default to dark mode
+		addEventListener: (_: string, cb: (e: Pick<MediaQueryListEvent, "matches">) => void) => {
+			listeners.push(cb);
+		},
+		removeEventListener: (_: string, cb: (e: Pick<MediaQueryListEvent, "matches">) => void) => {
+			const idx = listeners.indexOf(cb);
+			if (idx > -1) listeners.splice(idx, 1);
+		},
+	};
+
+	Object.defineProperty(window, "matchMedia", {
+		writable: true,
+		value: vi.fn().mockReturnValue(mql),
+	});
+}

--- a/tests/unit/lib/useTheme.test.ts
+++ b/tests/unit/lib/useTheme.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useTheme } from "../../../src/lib/useTheme";
+
+type ChangeListener = (e: Pick<MediaQueryListEvent, "matches">) => void;
+
+function mockMatchMedia(systemIsLight: boolean) {
+	const listeners: ChangeListener[] = [];
+	const mql = {
+		matches: systemIsLight,
+		addEventListener: (_: string, cb: ChangeListener) => {
+			listeners.push(cb);
+		},
+		removeEventListener: (_: string, cb: ChangeListener) => {
+			const idx = listeners.indexOf(cb);
+			if (idx > -1) listeners.splice(idx, 1);
+		},
+	};
+	Object.defineProperty(window, "matchMedia", {
+		writable: true,
+		value: vi.fn().mockReturnValue(mql),
+	});
+	return { mql, listeners, triggerChange: (matches: boolean) => {
+		listeners.forEach((cb) => cb({ matches }));
+	}};
+}
+
+beforeEach(() => {
+	document.documentElement.removeAttribute("data-theme");
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("useTheme", () => {
+	it("sets data-theme=dark when system preference is dark", () => {
+		mockMatchMedia(false);
+		renderHook(() => useTheme());
+		expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+	});
+
+	it("sets data-theme=light when system preference is light", () => {
+		mockMatchMedia(true);
+		renderHook(() => useTheme());
+		expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+	});
+
+	it("updates data-theme when system preference changes to light", () => {
+		const { triggerChange } = mockMatchMedia(false);
+		renderHook(() => useTheme());
+		expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+		act(() => triggerChange(true));
+		expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+	});
+
+	it("updates data-theme when system preference changes to dark", () => {
+		const { triggerChange } = mockMatchMedia(true);
+		renderHook(() => useTheme());
+		expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+		act(() => triggerChange(false));
+		expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+	});
+
+	it("setTheme('light') overrides system preference", () => {
+		mockMatchMedia(false); // system is dark
+		const { result } = renderHook(() => useTheme());
+		expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+		act(() => result.current.setTheme("light"));
+		expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+	});
+
+	it("setTheme('system') reverts to system preference", () => {
+		mockMatchMedia(true); // system is light
+		const { result } = renderHook(() => useTheme());
+		act(() => result.current.setTheme("dark")); // override to dark
+		expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+		act(() => result.current.setTheme("system")); // revert
+		expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+	});
+
+	it("returns the correct resolvedTheme value", () => {
+		mockMatchMedia(true);
+		const { result } = renderHook(() => useTheme());
+		expect(result.current.resolvedTheme).toBe("light");
+	});
+});

--- a/tests/unit/lib/useTheme.test.ts
+++ b/tests/unit/lib/useTheme.test.ts
@@ -25,11 +25,18 @@ function mockMatchMedia(systemIsLight: boolean) {
 	}};
 }
 
+let originalMatchMedia: typeof window.matchMedia;
+
 beforeEach(() => {
+	originalMatchMedia = window.matchMedia;
 	document.documentElement.removeAttribute("data-theme");
 });
 
 afterEach(() => {
+	Object.defineProperty(window, "matchMedia", {
+		writable: true,
+		value: originalMatchMedia,
+	});
 	vi.restoreAllMocks();
 });
 


### PR DESCRIPTION
## Summary

- Adds automatic dark/light theme switching that follows the **macOS system appearance** preference in real time (no app restart needed)
- Implements a `useTheme` hook that sets `data-theme` on `<html>` via `window.matchMedia`, making theme switching fully reactive
- All three Monaco editors (FileViewer, DiffViewer, CommitDiffStack) switch between `vs` and `vs-dark` in sync
- Architecture is ready for a future manual toggle — just call `setTheme('light' | 'dark' | 'system')`

## What Changed

| Layer | Change |
|---|---|
| `src/app/shell.css` | Added `[data-theme="light"]` variable block with Classic IDE Light palette; replaced 15+ hardcoded dark hex values with CSS vars |
| `src/lib/useTheme.ts` | New hook — reads system preference, sets DOM attribute, listens for changes |
| `src/app/App.tsx` | Calls `useTheme()` at root, passes `resolvedTheme` to viewer components |
| `src/features/viewer/FileViewer.tsx` | Monaco `Editor` theme follows `resolvedTheme` |
| `src/features/viewer/DiffViewer.tsx` | Monaco `DiffEditor` theme follows `resolvedTheme` |
| `src/features/git/CommitDiffStack.tsx` | Monaco `DiffEditor` in Commits tab follows `resolvedTheme` |
| `tests/unit/lib/useTheme.test.ts` | 7 unit tests (TDD) covering all hook behaviours |
| `tests/setup.ts` | Global `matchMedia` stub for jsdom (mirrors existing `ResizeObserver` stub) |

## Light Theme Palette

Classic IDE Light — white/light-gray panels, blue accent (VS Code-style).

| Token | Light | Dark |
|---|---|---|
| `--app-bg` | `#f0f2f5` | `#0b1116` |
| `--panel-bg` | `#ffffff` | `#111a21` |
| `--accent` | `#1a7fc1` | `#67d4b0` |
| `--text-primary` | `#1e2530` | `#eef7fa` |

## Screenshots

> 
<img width="1861" height="1049" alt="Screenshot 2026-04-10 at 08 30 11" src="https://github.com/user-attachments/assets/144547b2-8b95-48a0-a221-1a8ec14f137d" />

**Light mode — main view**

<!-- drag screenshot here -->

**Light mode — Commits tab (diff editor)**

<!-- drag screenshot here -->

## Notes

- The terminal canvas (xterm.js) always renders dark — this is expected and intentional
- A future in-app toggle button only needs to call `setTheme()` — no structural changes needed

## Test Plan

- [x] 325 unit tests passing
- [ ] Switch macOS Appearance to Light → app updates instantly, no reload
- [ ] Switch back to Dark → app reverts correctly
- [ ] Open a file in FileViewer → Monaco uses light theme
- [ ] Open a diff in DiffViewer and CommitDiffStack → Monaco uses light theme