### PR TITLE
feat(keyboard): keyboard shortcut system

### DIFF
--- a/electron/main/ipc.ts
+++ b/electron/main/ipc.ts
@@ -1,4 +1,6 @@
-import { dialog, ipcMain } from "electron";
+import { dialog, ipcMain, app } from "electron";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
 import { consumeE2eGitFault } from "./e2e-git-faults.js";
 import { consumeE2eTerminalCreateDelay } from "./e2e-terminal-create-delay.js";
 import type { BrowserWindow } from "electron";
@@ -30,6 +32,7 @@ import {
 	RemoveWorktreeSchema,
 	LogShellEventSchema,
 	ListTrackedFilesSchema,
+	LoadKeybindingsSchema,
 } from "../../shared/contracts/commands.js";
 import type { WorkspacePersistenceService } from "../../services/workspace/workspace-persistence-service.js";
 import { WorkspaceRegistryService } from "../../services/workspace/workspace-registry-service.js";
@@ -277,6 +280,19 @@ export function registerIpcHandlers(
 		const parsed = LogShellEventSchema.safeParse(raw);
 		if (!parsed.success) return;
 		shellEventLog?.log(parsed.data);
+	});
+
+	// --- Keyboard ---
+
+	ipcMain.handle("keyboard:loadKeybindings", async (_event, raw: unknown) => {
+		LoadKeybindingsSchema.parse(raw);
+		const filePath = join(app.getPath("userData"), "keybindings.json");
+		try {
+			return await readFile(filePath, "utf-8");
+		} catch (err: unknown) {
+			if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+			throw err;
+		}
 	});
 
 	return { dispose: () => terminalService.dispose() };

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -131,6 +131,11 @@ const api: Ai14AllDesktopApi = {
 			return ipcRenderer.invoke("diagnostics:logShellEvent", event);
 		},
 	},
+	keyboard: {
+		loadKeybindings() {
+			return ipcRenderer.invoke("keyboard:loadKeybindings", {});
+		},
+	},
 };
 
 contextBridge.exposeInMainWorld("ai14all", api);

--- a/shared/contracts/commands.ts
+++ b/shared/contracts/commands.ts
@@ -140,6 +140,8 @@ export const PushGitBranchSchema = z.object({
 	force: z.boolean(),
 });
 
+export const LoadKeybindingsSchema = z.object({});
+
 // --- The API surface exposed to the renderer via the preload bridge ---
 
 export type Ai14AllDesktopApi = {
@@ -189,5 +191,8 @@ export type Ai14AllDesktopApi = {
 	};
 	diagnostics: {
 		logShellEvent(event: z.infer<typeof LogShellEventSchema>): Promise<void>;
+	};
+	keyboard: {
+		loadKeybindings(): Promise<string | null>;
 	};
 };

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -360,6 +360,9 @@ export function App() {
 			const prev = wts[(idx - 1 + wts.length) % wts.length];
 			if (prev) dispatch({ type: "session/selectWorktree", worktreeId: prev.id });
 		},
+		"worktree.add": () => {
+			setCreateDialogOpen(true);
+		},
 		"workspace.selectNext": () => {
 			const aws = appWorkspacesRef.current;
 			const order = aws.workspaceOrder;

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -431,6 +431,9 @@ export function App() {
 			const state = workspaceStateRef.current;
 			dispatch({ type: "workspace/setTopBandCollapsed", collapsed: !state.topBandCollapsed });
 		},
+		"layout.toggleSidebar": () => {
+			setSidebarCollapsed((current) => !current);
+		},
 		"review.files": () => {
 			const awt = activeWorktreeRef.current;
 			if (awt) dispatch({ type: "session/setReviewMode", worktreeId: awt.id, reviewMode: "files" });

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -66,6 +66,7 @@ import { useTheme } from "../lib/useTheme";
 import { describeRepositoryLoadError } from "../features/repository/describe-repository-load-error";
 import { useKeyboardShortcuts } from "../features/keyboard/useKeyboardShortcuts";
 import { KeyboardContext } from "../features/keyboard/keyboard-context";
+import { ShortcutsHelpModal } from "../features/keyboard/ShortcutsHelpModal";
 
 type StartupMode = "loading" | "prompt" | "ready";
 
@@ -241,7 +242,6 @@ export function App() {
 	const [startupMode, setStartupMode] = useState<StartupMode>("loading");
 	const [workspacePickerOpen, setWorkspacePickerOpen] = useState(false);
 	const [shortcutsOpen, setShortcutsOpen] = useState(false);
-	void shortcutsOpen; // consumed by ShortcutsHelpModal in Task 7
 
 	// V2 restore state — restorePreference lives here; workspace snapshots are in appWorkspaces
 	const [restorePreference, setRestorePreference] = useState<RestorePreference>("prompt");
@@ -2644,6 +2644,11 @@ export function App() {
 				relativePath={discardPath}
 				onOpenChange={(open) => { if (!open) setDiscardPath(null); }}
 				onConfirm={handleDiscardChange}
+			/>
+			<ShortcutsHelpModal
+				open={shortcutsOpen}
+				onClose={() => setShortcutsOpen(false)}
+				registry={keyboardRegistry}
 			/>
 		</main>
 		</KeyboardContext.Provider>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -64,6 +64,8 @@ import { git, terminals, workspace, repository as repositoryClient } from "../li
 import { logRendererShellEvent } from "../features/terminals/shell-event-logger";
 import { useTheme } from "../lib/useTheme";
 import { describeRepositoryLoadError } from "../features/repository/describe-repository-load-error";
+import { useKeyboardShortcuts } from "../features/keyboard/useKeyboardShortcuts";
+import { KeyboardContext } from "../features/keyboard/keyboard-context";
 
 type StartupMode = "loading" | "prompt" | "ready";
 
@@ -238,6 +240,8 @@ export function App() {
 	const [confirmedDirtyRemoval, setConfirmedDirtyRemoval] = useState(false);
 	const [startupMode, setStartupMode] = useState<StartupMode>("loading");
 	const [workspacePickerOpen, setWorkspacePickerOpen] = useState(false);
+	const [shortcutsOpen, setShortcutsOpen] = useState(false);
+	void shortcutsOpen; // consumed by ShortcutsHelpModal in Task 7
 
 	// V2 restore state — restorePreference lives here; workspace snapshots are in appWorkspaces
 	const [restorePreference, setRestorePreference] = useState<RestorePreference>("prompt");
@@ -334,6 +338,116 @@ export function App() {
 
 	const activeWorktree =
 		worktrees.find((w) => w.id === workspaceState.selectedWorktreeId) ?? null;
+
+	// Only this ref is new — the others already exist in App.tsx
+	const activeWorktreeRef = useRef(activeWorktree);
+	activeWorktreeRef.current = activeWorktree;
+
+	const keyboardRegistry = useKeyboardShortcuts({
+		"worktree.selectNext": () => {
+			const wts = worktreesRef.current;
+			const state = workspaceStateRef.current;
+			if (wts.length === 0) return;
+			const idx = wts.findIndex((w) => w.id === state.selectedWorktreeId);
+			const next = wts[(idx + 1) % wts.length];
+			if (next) dispatch({ type: "session/selectWorktree", worktreeId: next.id });
+		},
+		"worktree.selectPrev": () => {
+			const wts = worktreesRef.current;
+			const state = workspaceStateRef.current;
+			if (wts.length === 0) return;
+			const idx = wts.findIndex((w) => w.id === state.selectedWorktreeId);
+			const prev = wts[(idx - 1 + wts.length) % wts.length];
+			if (prev) dispatch({ type: "session/selectWorktree", worktreeId: prev.id });
+		},
+		"workspace.selectNext": () => {
+			const aws = appWorkspacesRef.current;
+			const order = aws.workspaceOrder;
+			if (order.length === 0) return;
+			const idx = order.indexOf(aws.activeWorkspaceId ?? "");
+			const nextId = order[(idx + 1) % order.length];
+			if (nextId) dispatchAppWorkspaces({ type: "workspace/select", workspaceId: nextId });
+		},
+		"workspace.selectPrev": () => {
+			const aws = appWorkspacesRef.current;
+			const order = aws.workspaceOrder;
+			if (order.length === 0) return;
+			const idx = order.indexOf(aws.activeWorkspaceId ?? "");
+			const prevId = order[(idx - 1 + order.length) % order.length];
+			if (prevId) dispatchAppWorkspaces({ type: "workspace/select", workspaceId: prevId });
+		},
+		"terminal.new": () => {
+			void handleAddAdHoc();
+		},
+		"terminal.close": () => {
+			const state = workspaceStateRef.current;
+			const awt = activeWorktreeRef.current;
+			if (!awt) return;
+			const session = state.sessionsByWorktreeId[awt.id];
+			if (session?.activeProcessSessionId) {
+				void handleCloseProcess(session.activeProcessSessionId);
+			}
+		},
+		"terminal.selectNext": () => {
+			const state = workspaceStateRef.current;
+			const awt = activeWorktreeRef.current;
+			if (!awt) return;
+			const session = state.sessionsByWorktreeId[awt.id];
+			if (!session) return;
+			const ids = session.processSessionIds;
+			if (ids.length === 0) return;
+			const idx = ids.indexOf(session.activeProcessSessionId ?? "");
+			const nextId = ids[(idx + 1) % ids.length];
+			if (nextId) dispatch({ type: "session/selectProcess", worktreeId: awt.id, processId: nextId });
+		},
+		"terminal.selectPrev": () => {
+			const state = workspaceStateRef.current;
+			const awt = activeWorktreeRef.current;
+			if (!awt) return;
+			const session = state.sessionsByWorktreeId[awt.id];
+			if (!session) return;
+			const ids = session.processSessionIds;
+			if (ids.length === 0) return;
+			const idx = ids.indexOf(session.activeProcessSessionId ?? "");
+			const prevId = ids[(idx - 1 + ids.length) % ids.length];
+			if (prevId) dispatch({ type: "session/selectProcess", worktreeId: awt.id, processId: prevId });
+		},
+		"terminal.toggleSplit": () => {
+			const state = workspaceStateRef.current;
+			const awt = activeWorktreeRef.current;
+			if (!awt) return;
+			const session = state.sessionsByWorktreeId[awt.id];
+			if (!session) return;
+			dispatch({
+				type: "session/setTerminalLayoutMode",
+				worktreeId: awt.id,
+				layoutMode: session.terminalLayoutMode === "single" ? "split" : "single",
+			});
+		},
+		"layout.toggleTopBand": () => {
+			const state = workspaceStateRef.current;
+			dispatch({ type: "workspace/setTopBandCollapsed", collapsed: !state.topBandCollapsed });
+		},
+		"review.files": () => {
+			const awt = activeWorktreeRef.current;
+			if (awt) dispatch({ type: "session/setReviewMode", worktreeId: awt.id, reviewMode: "files" });
+		},
+		"review.changes": () => {
+			const awt = activeWorktreeRef.current;
+			if (awt) dispatch({ type: "session/setReviewMode", worktreeId: awt.id, reviewMode: "changes" });
+		},
+		"review.commits": () => {
+			const awt = activeWorktreeRef.current;
+			if (awt) dispatch({ type: "session/setReviewMode", worktreeId: awt.id, reviewMode: "commits" });
+		},
+		"ui.openWorkspacePicker": () => {
+			setWorkspacePickerOpen(true);
+		},
+		"ui.showShortcuts": () => {
+			setShortcutsOpen(true);
+		},
+	});
+
 	const activeSession = workspaceState.selectedWorktreeId
 		? (workspaceState.sessionsByWorktreeId[workspaceState.selectedWorktreeId] ??
 			null)
@@ -1956,6 +2070,7 @@ export function App() {
 	}
 
 	return (
+		<KeyboardContext.Provider value={keyboardRegistry}>
 		<main className="shell-app">
 			{restoreWarning && (
 				<div className="shell-restore-warning" role="status">
@@ -2531,5 +2646,6 @@ export function App() {
 				onConfirm={handleDiscardChange}
 			/>
 		</main>
+		</KeyboardContext.Provider>
 	);
 }

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -1719,3 +1719,80 @@ select {
 .shell-modal--workspace-picker {
 	width: min(640px, calc(100vw - 32px));
 }
+
+.shell-shortcuts-modal {
+	width: min(520px, calc(100vw - 32px));
+	max-height: calc(100vh - 64px);
+	overflow-y: auto;
+}
+
+.shell-shortcuts-modal__title {
+	font-size: var(--font-size-body);
+	font-weight: 600;
+	color: var(--text-primary);
+	padding-right: var(--space-6);
+	margin: 0 0 var(--space-3) 0;
+}
+
+.shell-shortcuts-modal__close {
+	position: absolute;
+	top: var(--space-3);
+	right: var(--space-3);
+	background: none;
+	border: none;
+	color: var(--text-secondary);
+	cursor: pointer;
+	font-size: var(--font-size-body);
+	line-height: 1;
+	padding: var(--space-1);
+	border-radius: var(--radius-sm);
+}
+
+.shell-shortcuts-modal__close:hover {
+	color: var(--text-primary);
+}
+
+.shell-shortcuts-modal__groups {
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-2);
+}
+
+.shell-shortcuts-modal__group {
+	border: 1px solid var(--panel-border);
+	border-radius: var(--radius-sm);
+	padding: var(--space-2) var(--space-3);
+}
+
+.shell-shortcuts-modal__group-label {
+	font-size: var(--font-size-label);
+	font-weight: 600;
+	color: var(--text-secondary);
+	margin: 0 0 var(--space-2) 0;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+}
+
+.shell-shortcuts-modal__table {
+	width: 100%;
+	border-collapse: collapse;
+}
+
+.shell-shortcuts-modal__table tr + tr td {
+	padding-top: var(--space-1);
+}
+
+.shell-shortcuts-modal__action-label {
+	color: var(--text-primary);
+	font-size: var(--font-size-body);
+	width: 100%;
+}
+
+.shell-shortcuts-modal__key {
+	white-space: nowrap;
+	text-align: right;
+	color: var(--text-secondary);
+	font-size: var(--font-size-label);
+	font-family: ui-monospace, monospace;
+	padding-left: var(--space-4);
+}

--- a/src/features/keyboard/ShortcutsHelpModal.tsx
+++ b/src/features/keyboard/ShortcutsHelpModal.tsx
@@ -1,0 +1,60 @@
+import { useMemo } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { ACTION_GROUPS, ACTION_LABELS } from "./default-keybindings";
+import type { ShortcutRegistry } from "./shortcut-registry";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  registry: ShortcutRegistry;
+};
+
+export function ShortcutsHelpModal({ open, onClose, registry }: Props) {
+  const displayMap = useMemo(
+    () => Object.fromEntries(registry.list().map((s) => [s.action, s.displayKey])),
+    [registry],
+  );
+
+  return (
+    <Dialog.Root open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="shell-dialog-overlay" />
+        <Dialog.Content
+          className="shell-dialog-content shell-shortcuts-modal"
+          aria-label="Keyboard shortcuts"
+        >
+          <Dialog.Title className="shell-shortcuts-modal__title">
+            Keyboard Shortcuts
+          </Dialog.Title>
+          <div className="shell-shortcuts-modal__groups">
+            {ACTION_GROUPS.map((group) => (
+              <div key={group.label} className="shell-shortcuts-modal__group">
+                <h3 className="shell-shortcuts-modal__group-label">{group.label}</h3>
+                <table className="shell-shortcuts-modal__table">
+                  <tbody>
+                    {group.actions.map((action) => (
+                      <tr key={action}>
+                        <td className="shell-shortcuts-modal__action-label">
+                          {ACTION_LABELS[action] ?? action}
+                        </td>
+                        <td className="shell-shortcuts-modal__key">
+                          {displayMap[action] ?? "—"}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ))}
+          </div>
+          <Dialog.Close
+            className="shell-shortcuts-modal__close"
+            aria-label="Close shortcuts"
+          >
+            ✕
+          </Dialog.Close>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/features/keyboard/ShortcutsHelpModal.tsx
+++ b/src/features/keyboard/ShortcutsHelpModal.tsx
@@ -18,10 +18,11 @@ export function ShortcutsHelpModal({ open, onClose, registry }: Props) {
   return (
     <Dialog.Root open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
       <Dialog.Portal>
-        <Dialog.Overlay className="shell-dialog-overlay" />
+        <Dialog.Overlay className="shell-modal-overlay" />
         <Dialog.Content
-          className="shell-dialog-content shell-shortcuts-modal"
+          className="shell-modal shell-shortcuts-modal"
           aria-label="Keyboard shortcuts"
+          aria-describedby={undefined}
         >
           <Dialog.Title className="shell-shortcuts-modal__title">
             Keyboard Shortcuts

--- a/src/features/keyboard/default-keybindings.test.ts
+++ b/src/features/keyboard/default-keybindings.test.ts
@@ -9,13 +9,14 @@ describe("getDefaultBindings", () => {
     expect(unique.size).toBe(keys.length);
   });
 
-  it("contains all 16 expected actions for macos", () => {
+  it("contains all 17 expected actions for macos", () => {
     const bindings = getDefaultBindings("macos");
     const actions = bindings.map((b) => b.action);
     expect(actions).toContain("worktree.selectNext");
     expect(actions).toContain("terminal.new");
     expect(actions).toContain("ui.showShortcuts");
     expect(actions).toContain("worktree.add");
-    expect(bindings).toHaveLength(16);
+    expect(actions).toContain("layout.toggleSidebar");
+    expect(bindings).toHaveLength(17);
   });
 });

--- a/src/features/keyboard/default-keybindings.test.ts
+++ b/src/features/keyboard/default-keybindings.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { getDefaultBindings } from "./default-keybindings";
+
+describe("getDefaultBindings", () => {
+  it("has no duplicate key combos for macos", () => {
+    const bindings = getDefaultBindings("macos");
+    const keys = bindings.map((b) => b.key.toLowerCase());
+    const unique = new Set(keys);
+    expect(unique.size).toBe(keys.length);
+  });
+
+  it("contains all 15 expected actions for macos", () => {
+    const bindings = getDefaultBindings("macos");
+    const actions = bindings.map((b) => b.action);
+    expect(actions).toContain("worktree.selectNext");
+    expect(actions).toContain("terminal.new");
+    expect(actions).toContain("ui.showShortcuts");
+    expect(bindings).toHaveLength(15);
+  });
+});

--- a/src/features/keyboard/default-keybindings.test.ts
+++ b/src/features/keyboard/default-keybindings.test.ts
@@ -9,12 +9,13 @@ describe("getDefaultBindings", () => {
     expect(unique.size).toBe(keys.length);
   });
 
-  it("contains all 15 expected actions for macos", () => {
+  it("contains all 16 expected actions for macos", () => {
     const bindings = getDefaultBindings("macos");
     const actions = bindings.map((b) => b.action);
     expect(actions).toContain("worktree.selectNext");
     expect(actions).toContain("terminal.new");
     expect(actions).toContain("ui.showShortcuts");
-    expect(bindings).toHaveLength(15);
+    expect(actions).toContain("worktree.add");
+    expect(bindings).toHaveLength(16);
   });
 });

--- a/src/features/keyboard/default-keybindings.ts
+++ b/src/features/keyboard/default-keybindings.ts
@@ -1,0 +1,58 @@
+import type { Platform } from "./shortcut-registry";
+
+export type ActionGroup = {
+  label: string;
+  actions: string[];
+};
+
+export const ACTION_LABELS: Record<string, string> = {
+  "worktree.selectNext":    "Next worktree",
+  "worktree.selectPrev":    "Previous worktree",
+  "workspace.selectNext":   "Next workspace",
+  "workspace.selectPrev":   "Previous workspace",
+  "terminal.new":           "New terminal",
+  "terminal.close":         "Close terminal",
+  "terminal.selectNext":    "Next terminal",
+  "terminal.selectPrev":    "Previous terminal",
+  "terminal.toggleSplit":   "Toggle split mode",
+  "layout.toggleTopBand":   "Collapse / expand top band",
+  "review.files":           "Files",
+  "review.changes":         "Changes",
+  "review.commits":         "Commits",
+  "ui.openWorkspacePicker": "Open workspace picker",
+  "ui.showShortcuts":       "Show shortcuts",
+};
+
+export const ACTION_GROUPS: ActionGroup[] = [
+  { label: "Worktree",  actions: ["worktree.selectNext", "worktree.selectPrev"] },
+  { label: "Workspace", actions: ["workspace.selectNext", "workspace.selectPrev"] },
+  { label: "Terminal",  actions: ["terminal.new", "terminal.close", "terminal.selectNext", "terminal.selectPrev", "terminal.toggleSplit"] },
+  { label: "Layout",    actions: ["layout.toggleTopBand"] },
+  { label: "Review",    actions: ["review.files", "review.changes", "review.commits"] },
+  { label: "App",       actions: ["ui.openWorkspacePicker", "ui.showShortcuts"] },
+];
+
+const MACOS_DEFAULTS: Array<{ action: string; key: string }> = [
+  { action: "worktree.selectNext",    key: "cmd+]" },
+  { action: "worktree.selectPrev",    key: "cmd+[" },
+  { action: "workspace.selectNext",   key: "cmd+shift+]" },
+  { action: "workspace.selectPrev",   key: "cmd+shift+[" },
+  { action: "terminal.new",           key: "cmd+t" },
+  { action: "terminal.close",         key: "cmd+shift+w" },
+  { action: "terminal.selectNext",    key: "cmd+shift+k" },
+  { action: "terminal.selectPrev",    key: "cmd+shift+j" },
+  { action: "terminal.toggleSplit",   key: "cmd+d" },
+  { action: "layout.toggleTopBand",   key: "cmd+b" },
+  { action: "review.files",           key: "cmd+1" },
+  { action: "review.changes",         key: "cmd+2" },
+  { action: "review.commits",         key: "cmd+3" },
+  { action: "ui.openWorkspacePicker", key: "cmd+o" },
+  { action: "ui.showShortcuts",       key: "cmd+/" },
+];
+
+export function getDefaultBindings(platform: Platform): Array<{ action: string; key: string }> {
+  switch (platform) {
+    case "macos": return MACOS_DEFAULTS;
+    default:      return MACOS_DEFAULTS;
+  }
+}

--- a/src/features/keyboard/default-keybindings.ts
+++ b/src/features/keyboard/default-keybindings.ts
@@ -8,6 +8,7 @@ export type ActionGroup = {
 export const ACTION_LABELS: Record<string, string> = {
   "worktree.selectNext":    "Next worktree",
   "worktree.selectPrev":    "Previous worktree",
+  "worktree.add":           "Add worktree",
   "workspace.selectNext":   "Next workspace",
   "workspace.selectPrev":   "Previous workspace",
   "terminal.new":           "New terminal",
@@ -24,7 +25,7 @@ export const ACTION_LABELS: Record<string, string> = {
 };
 
 export const ACTION_GROUPS: ActionGroup[] = [
-  { label: "Worktree",  actions: ["worktree.selectNext", "worktree.selectPrev"] },
+  { label: "Worktree",  actions: ["worktree.selectNext", "worktree.selectPrev", "worktree.add"] },
   { label: "Workspace", actions: ["workspace.selectNext", "workspace.selectPrev"] },
   { label: "Terminal",  actions: ["terminal.new", "terminal.close", "terminal.selectNext", "terminal.selectPrev", "terminal.toggleSplit"] },
   { label: "Layout",    actions: ["layout.toggleTopBand"] },
@@ -35,6 +36,7 @@ export const ACTION_GROUPS: ActionGroup[] = [
 const MACOS_DEFAULTS: Array<{ action: string; key: string }> = [
   { action: "worktree.selectNext",    key: "cmd+]" },
   { action: "worktree.selectPrev",    key: "cmd+[" },
+  { action: "worktree.add",           key: "cmd+n" },
   { action: "workspace.selectNext",   key: "cmd+shift+]" },
   { action: "workspace.selectPrev",   key: "cmd+shift+[" },
   { action: "terminal.new",           key: "cmd+t" },
@@ -47,7 +49,7 @@ const MACOS_DEFAULTS: Array<{ action: string; key: string }> = [
   { action: "review.changes",         key: "cmd+2" },
   { action: "review.commits",         key: "cmd+3" },
   { action: "ui.openWorkspacePicker", key: "cmd+o" },
-  { action: "ui.showShortcuts",       key: "cmd+/" },
+  { action: "ui.showShortcuts",       key: "cmd+shift+/" },
 ];
 
 export function getDefaultBindings(platform: Platform): Array<{ action: string; key: string }> {

--- a/src/features/keyboard/default-keybindings.ts
+++ b/src/features/keyboard/default-keybindings.ts
@@ -17,6 +17,7 @@ export const ACTION_LABELS: Record<string, string> = {
   "terminal.selectPrev":    "Previous terminal",
   "terminal.toggleSplit":   "Toggle split mode",
   "layout.toggleTopBand":   "Collapse / expand top band",
+  "layout.toggleSidebar":   "Toggle sidebar",
   "review.files":           "Files",
   "review.changes":         "Changes",
   "review.commits":         "Commits",
@@ -28,7 +29,7 @@ export const ACTION_GROUPS: ActionGroup[] = [
   { label: "Worktree",  actions: ["worktree.selectNext", "worktree.selectPrev", "worktree.add"] },
   { label: "Workspace", actions: ["workspace.selectNext", "workspace.selectPrev"] },
   { label: "Terminal",  actions: ["terminal.new", "terminal.close", "terminal.selectNext", "terminal.selectPrev", "terminal.toggleSplit"] },
-  { label: "Layout",    actions: ["layout.toggleTopBand"] },
+  { label: "Layout",    actions: ["layout.toggleTopBand", "layout.toggleSidebar"] },
   { label: "Review",    actions: ["review.files", "review.changes", "review.commits"] },
   { label: "App",       actions: ["ui.openWorkspacePicker", "ui.showShortcuts"] },
 ];
@@ -45,11 +46,12 @@ const MACOS_DEFAULTS: Array<{ action: string; key: string }> = [
   { action: "terminal.selectPrev",    key: "cmd+shift+j" },
   { action: "terminal.toggleSplit",   key: "cmd+d" },
   { action: "layout.toggleTopBand",   key: "cmd+b" },
+  { action: "layout.toggleSidebar",   key: "cmd+shift+b" },
   { action: "review.files",           key: "cmd+1" },
   { action: "review.changes",         key: "cmd+2" },
   { action: "review.commits",         key: "cmd+3" },
   { action: "ui.openWorkspacePicker", key: "cmd+o" },
-  { action: "ui.showShortcuts",       key: "cmd+shift+/" },
+  { action: "ui.showShortcuts",       key: "cmd+shift+p" },
 ];
 
 export function getDefaultBindings(platform: Platform): Array<{ action: string; key: string }> {

--- a/src/features/keyboard/default-keybindings.ts
+++ b/src/features/keyboard/default-keybindings.ts
@@ -1,62 +1,87 @@
 import type { Platform } from "./shortcut-registry";
 
 export type ActionGroup = {
-  label: string;
-  actions: string[];
+	label: string;
+	actions: string[];
 };
 
 export const ACTION_LABELS: Record<string, string> = {
-  "worktree.selectNext":    "Next worktree",
-  "worktree.selectPrev":    "Previous worktree",
-  "worktree.add":           "Add worktree",
-  "workspace.selectNext":   "Next workspace",
-  "workspace.selectPrev":   "Previous workspace",
-  "terminal.new":           "New terminal",
-  "terminal.close":         "Close terminal",
-  "terminal.selectNext":    "Next terminal",
-  "terminal.selectPrev":    "Previous terminal",
-  "terminal.toggleSplit":   "Toggle split mode",
-  "layout.toggleTopBand":   "Collapse / expand top band",
-  "layout.toggleSidebar":   "Toggle sidebar",
-  "review.files":           "Files",
-  "review.changes":         "Changes",
-  "review.commits":         "Commits",
-  "ui.openWorkspacePicker": "Open workspace picker",
-  "ui.showShortcuts":       "Show shortcuts",
+	"worktree.selectNext": "Next worktree",
+	"worktree.selectPrev": "Previous worktree",
+	"worktree.add": "Add worktree",
+	"workspace.selectNext": "Next workspace",
+	"workspace.selectPrev": "Previous workspace",
+	"terminal.new": "New terminal",
+	"terminal.close": "Close terminal",
+	"terminal.selectNext": "Next terminal",
+	"terminal.selectPrev": "Previous terminal",
+	"terminal.toggleSplit": "Toggle split mode",
+	"layout.toggleTopBand": "Collapse / expand top band",
+	"layout.toggleSidebar": "Toggle sidebar",
+	"review.files": "Files",
+	"review.changes": "Changes",
+	"review.commits": "Commits",
+	"ui.openWorkspacePicker": "Open workspace picker",
+	"ui.showShortcuts": "Show shortcuts",
 };
 
 export const ACTION_GROUPS: ActionGroup[] = [
-  { label: "Worktree",  actions: ["worktree.selectNext", "worktree.selectPrev", "worktree.add"] },
-  { label: "Workspace", actions: ["workspace.selectNext", "workspace.selectPrev"] },
-  { label: "Terminal",  actions: ["terminal.new", "terminal.close", "terminal.selectNext", "terminal.selectPrev", "terminal.toggleSplit"] },
-  { label: "Layout",    actions: ["layout.toggleTopBand", "layout.toggleSidebar"] },
-  { label: "Review",    actions: ["review.files", "review.changes", "review.commits"] },
-  { label: "App",       actions: ["ui.openWorkspacePicker", "ui.showShortcuts"] },
+	{
+		label: "Worktree",
+		actions: ["worktree.selectNext", "worktree.selectPrev", "worktree.add"],
+	},
+	{
+		label: "Workspace",
+		actions: ["workspace.selectNext", "workspace.selectPrev"],
+	},
+	{
+		label: "Terminal",
+		actions: [
+			"terminal.new",
+			"terminal.close",
+			"terminal.selectNext",
+			"terminal.selectPrev",
+			"terminal.toggleSplit",
+		],
+	},
+	{
+		label: "Layout",
+		actions: ["layout.toggleTopBand", "layout.toggleSidebar"],
+	},
+	{
+		label: "Review",
+		actions: ["review.files", "review.changes", "review.commits"],
+	},
+	{ label: "App", actions: ["ui.openWorkspacePicker", "ui.showShortcuts"] },
 ];
 
 const MACOS_DEFAULTS: Array<{ action: string; key: string }> = [
-  { action: "worktree.selectNext",    key: "cmd+]" },
-  { action: "worktree.selectPrev",    key: "cmd+[" },
-  { action: "worktree.add",           key: "cmd+n" },
-  { action: "workspace.selectNext",   key: "cmd+shift+]" },
-  { action: "workspace.selectPrev",   key: "cmd+shift+[" },
-  { action: "terminal.new",           key: "cmd+t" },
-  { action: "terminal.close",         key: "cmd+shift+w" },
-  { action: "terminal.selectNext",    key: "cmd+shift+k" },
-  { action: "terminal.selectPrev",    key: "cmd+shift+j" },
-  { action: "terminal.toggleSplit",   key: "cmd+d" },
-  { action: "layout.toggleTopBand",   key: "cmd+b" },
-  { action: "layout.toggleSidebar",   key: "cmd+shift+b" },
-  { action: "review.files",           key: "cmd+1" },
-  { action: "review.changes",         key: "cmd+2" },
-  { action: "review.commits",         key: "cmd+3" },
-  { action: "ui.openWorkspacePicker", key: "cmd+o" },
-  { action: "ui.showShortcuts",       key: "cmd+shift+p" },
+	{ action: "worktree.selectNext", key: "cmd+]" },
+	{ action: "worktree.selectPrev", key: "cmd+[" },
+	{ action: "worktree.add", key: "cmd+n" },
+	{ action: "workspace.selectNext", key: "cmd+shift+]" },
+	{ action: "workspace.selectPrev", key: "cmd+shift+[" },
+	{ action: "terminal.new", key: "cmd+t" },
+	{ action: "terminal.close", key: "cmd+shift+w" },
+	{ action: "terminal.selectNext", key: "cmd+shift+d" },
+	{ action: "terminal.selectPrev", key: "cmd+shift+a" },
+	{ action: "terminal.toggleSplit", key: "cmd+d" },
+	{ action: "layout.toggleTopBand", key: "cmd+shift+b" },
+	{ action: "layout.toggleSidebar", key: "cmd+b" },
+	{ action: "review.files", key: "cmd+1" },
+	{ action: "review.changes", key: "cmd+2" },
+	{ action: "review.commits", key: "cmd+3" },
+	{ action: "ui.openWorkspacePicker", key: "cmd+o" },
+	{ action: "ui.showShortcuts", key: "cmd+shift+p" },
 ];
 
-export function getDefaultBindings(platform: Platform): Array<{ action: string; key: string }> {
-  switch (platform) {
-    case "macos": return MACOS_DEFAULTS;
-    default:      return MACOS_DEFAULTS;
-  }
+export function getDefaultBindings(
+	platform: Platform,
+): Array<{ action: string; key: string }> {
+	switch (platform) {
+		case "macos":
+			return MACOS_DEFAULTS;
+		default:
+			return MACOS_DEFAULTS;
+	}
 }

--- a/src/features/keyboard/keybindings-schema.ts
+++ b/src/features/keyboard/keybindings-schema.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const KeyBindingEntrySchema = z.object({
+  action: z.string().min(1),
+  key: z.string().min(1),
+});
+
+export const KeybindingsFileSchema = z.object({
+  version: z.literal(1),
+  bindings: z.array(KeyBindingEntrySchema),
+});
+
+export type KeyBindingEntry = z.infer<typeof KeyBindingEntrySchema>;
+export type KeybindingsFile = z.infer<typeof KeybindingsFileSchema>;

--- a/src/features/keyboard/keyboard-context.ts
+++ b/src/features/keyboard/keyboard-context.ts
@@ -1,0 +1,8 @@
+import { createContext, useContext } from "react";
+import type { ShortcutRegistry } from "./shortcut-registry";
+
+export const KeyboardContext = createContext<ShortcutRegistry | null>(null);
+
+export function useKeyboardRegistry(): ShortcutRegistry | null {
+  return useContext(KeyboardContext);
+}

--- a/src/features/keyboard/shortcut-registry.test.ts
+++ b/src/features/keyboard/shortcut-registry.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  detectPlatform,
+  parseBinding,
+  buildShortcutRegistry,
+} from "./shortcut-registry";
+
+describe("detectPlatform", () => {
+  let originalUserAgent: string;
+  beforeEach(() => {
+    originalUserAgent = navigator.userAgent;
+  });
+  afterEach(() => {
+    Object.defineProperty(navigator, "userAgent", {
+      value: originalUserAgent,
+      configurable: true,
+    });
+  });
+
+  it("returns macos when userAgent contains Mac", () => {
+    Object.defineProperty(navigator, "userAgent", {
+      value: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+      configurable: true,
+    });
+    expect(detectPlatform()).toBe("macos");
+  });
+
+  it("returns windows when userAgent contains Win", () => {
+    Object.defineProperty(navigator, "userAgent", {
+      value: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+      configurable: true,
+    });
+    expect(detectPlatform()).toBe("windows");
+  });
+
+  it("returns linux as fallback", () => {
+    Object.defineProperty(navigator, "userAgent", {
+      value: "Mozilla/5.0 (X11; Linux x86_64)",
+      configurable: true,
+    });
+    expect(detectPlatform()).toBe("linux");
+  });
+});
+
+describe("parseBinding", () => {
+  it("parses cmd+] on macos to metaKey=true", () => {
+    const result = parseBinding("cmd+]", "macos");
+    expect(result).toEqual({ metaKey: true, ctrlKey: false, shiftKey: false, altKey: false, key: "]" });
+  });
+
+  it("parses cmd+] on linux to ctrlKey=true", () => {
+    const result = parseBinding("cmd+]", "linux");
+    expect(result).toEqual({ metaKey: false, ctrlKey: true, shiftKey: false, altKey: false, key: "]" });
+  });
+
+  it("parses cmd+shift+] correctly", () => {
+    const result = parseBinding("cmd+shift+]", "macos");
+    expect(result).toEqual({ metaKey: true, ctrlKey: false, shiftKey: true, altKey: false, key: "]" });
+  });
+
+  it("parses key names case-insensitively", () => {
+    const result = parseBinding("CMD+SHIFT+T", "macos");
+    expect(result).toEqual({ metaKey: true, ctrlKey: false, shiftKey: true, altKey: false, key: "t" });
+  });
+
+  it("returns null for an empty string", () => {
+    expect(parseBinding("", "macos")).toBeNull();
+  });
+});
+
+describe("buildShortcutRegistry", () => {
+  const bindings = [
+    { action: "test.alpha", key: "cmd+]" },
+    { action: "test.beta",  key: "cmd+shift+]" },
+  ];
+
+  it("matchesAny returns true for a registered key", () => {
+    const registry = buildShortcutRegistry(bindings, "macos");
+    const event = new KeyboardEvent("keydown", { metaKey: true, key: "]" });
+    expect(registry.matchesAny(event)).toBe(true);
+  });
+
+  it("matchesAny returns false for an unregistered key", () => {
+    const registry = buildShortcutRegistry(bindings, "macos");
+    const event = new KeyboardEvent("keydown", { metaKey: true, key: "p" });
+    expect(registry.matchesAny(event)).toBe(false);
+  });
+
+  it("resolve returns the correct action", () => {
+    const registry = buildShortcutRegistry(bindings, "macos");
+    const event = new KeyboardEvent("keydown", { metaKey: true, shiftKey: true, key: "]" });
+    expect(registry.resolve(event)).toBe("test.beta");
+  });
+
+  it("resolve returns null for an unmatched event", () => {
+    const registry = buildShortcutRegistry(bindings, "macos");
+    const event = new KeyboardEvent("keydown", { metaKey: true, key: "z" });
+    expect(registry.resolve(event)).toBeNull();
+  });
+
+  it("last binding wins for a duplicate key combo", () => {
+    const dupes = [
+      { action: "test.first",  key: "cmd+]" },
+      { action: "test.second", key: "cmd+]" },
+    ];
+    const registry = buildShortcutRegistry(dupes, "macos");
+    const event = new KeyboardEvent("keydown", { metaKey: true, key: "]" });
+    expect(registry.resolve(event)).toBe("test.second");
+  });
+
+  it("list returns all registered shortcuts", () => {
+    const registry = buildShortcutRegistry(bindings, "macos");
+    const list = registry.list();
+    expect(list.map((s) => s.action)).toEqual(["test.alpha", "test.beta"]);
+  });
+
+  it("list includes a displayKey formatted for macos", () => {
+    const registry = buildShortcutRegistry([{ action: "test.alpha", key: "cmd+shift+]" }], "macos");
+    const [shortcut] = registry.list();
+    expect(shortcut?.displayKey).toContain("⌘");
+    expect(shortcut?.displayKey).toContain("⇧");
+  });
+
+  it("skips entries with invalid key strings", () => {
+    const registry = buildShortcutRegistry([{ action: "test.bad", key: "" }], "macos");
+    expect(registry.list()).toHaveLength(0);
+  });
+});

--- a/src/features/keyboard/shortcut-registry.ts
+++ b/src/features/keyboard/shortcut-registry.ts
@@ -1,0 +1,111 @@
+export type Platform = "macos" | "linux" | "windows";
+
+export type NormalizedBinding = {
+  metaKey: boolean;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+  key: string;
+};
+
+export type RegisteredShortcut = {
+  action: string;
+  rawKey: string;
+  displayKey: string;
+};
+
+export type ShortcutRegistry = {
+  matchesAny(event: KeyboardEvent): boolean;
+  resolve(event: KeyboardEvent): string | null;
+  list(): RegisteredShortcut[];
+};
+
+const PLATFORM_MODIFIER: Record<Platform, "metaKey" | "ctrlKey"> = {
+  macos: "metaKey",
+  linux: "ctrlKey",
+  windows: "ctrlKey",
+};
+
+const DISPLAY_MODIFIER: Record<Platform, { cmd: string; shift: string; alt: string; ctrl: string }> = {
+  macos:   { cmd: "⌘", shift: "⇧", alt: "⌥", ctrl: "⌃" },
+  linux:   { cmd: "Ctrl", shift: "Shift", alt: "Alt", ctrl: "Ctrl" },
+  windows: { cmd: "Ctrl", shift: "Shift", alt: "Alt", ctrl: "Ctrl" },
+};
+
+export function detectPlatform(): Platform {
+  const ua = navigator.userAgent;
+  if (ua.includes("Mac")) return "macos";
+  if (ua.includes("Win")) return "windows";
+  return "linux";
+}
+
+export function parseBinding(raw: string, platform: Platform): NormalizedBinding | null {
+  if (!raw) return null;
+  const parts = raw.toLowerCase().split("+");
+  const keyPart = parts[parts.length - 1];
+  if (!keyPart) return null;
+  const modifiers = new Set(parts.slice(0, -1));
+  const platformModifier = PLATFORM_MODIFIER[platform];
+  return {
+    metaKey: platformModifier === "metaKey" && modifiers.has("cmd"),
+    ctrlKey: platformModifier === "ctrlKey"
+      ? modifiers.has("cmd") || modifiers.has("ctrl")
+      : modifiers.has("ctrl"),
+    shiftKey: modifiers.has("shift"),
+    altKey: modifiers.has("alt"),
+    key: keyPart,
+  };
+}
+
+function makeKey(b: { metaKey: boolean; ctrlKey: boolean; shiftKey: boolean; altKey: boolean; key: string }): string {
+  return `${b.metaKey ? "1" : "0"}${b.ctrlKey ? "1" : "0"}${b.shiftKey ? "1" : "0"}${b.altKey ? "1" : "0"}:${b.key.toLowerCase()}`;
+}
+
+function formatDisplayKey(raw: string, platform: Platform): string {
+  const parts = raw.toLowerCase().split("+");
+  const keyPart = parts[parts.length - 1] ?? "";
+  const modifiers = new Set(parts.slice(0, -1));
+  const d = DISPLAY_MODIFIER[platform];
+  const out: string[] = [];
+  if (modifiers.has("cmd")) out.push(d.cmd);
+  if (modifiers.has("ctrl")) out.push(d.ctrl);
+  if (modifiers.has("shift")) out.push(d.shift);
+  if (modifiers.has("alt")) out.push(d.alt);
+  out.push(keyPart.toUpperCase());
+  return out.join(" ");
+}
+
+export function buildShortcutRegistry(
+  bindings: Array<{ action: string; key: string }>,
+  platform: Platform,
+): ShortcutRegistry {
+  const keyToAction = new Map<string, string>();
+  const shortcuts: RegisteredShortcut[] = [];
+
+  for (const { action, key } of bindings) {
+    const normalized = parseBinding(key, platform);
+    if (!normalized) continue;
+    const k = makeKey(normalized);
+    keyToAction.set(k, action);
+    const shortcut: RegisteredShortcut = {
+      action,
+      rawKey: key,
+      displayKey: formatDisplayKey(key, platform),
+    };
+    const existingIdx = shortcuts.findIndex((s) => s.action === action);
+    if (existingIdx >= 0) shortcuts[existingIdx] = shortcut;
+    else shortcuts.push(shortcut);
+  }
+
+  return {
+    matchesAny(event) {
+      return keyToAction.has(makeKey(event));
+    },
+    resolve(event) {
+      return keyToAction.get(makeKey(event)) ?? null;
+    },
+    list() {
+      return [...shortcuts];
+    },
+  };
+}

--- a/src/features/keyboard/useKeyboardShortcuts.test.ts
+++ b/src/features/keyboard/useKeyboardShortcuts.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useKeyboardShortcuts } from "./useKeyboardShortcuts";
+
+// Mock the IPC client
+vi.mock("../../lib/desktop-client", () => ({
+  keyboard: {
+    loadKeybindings: vi.fn(),
+  },
+}));
+
+import { keyboard } from "../../lib/desktop-client";
+
+const validConfig = JSON.stringify({
+  version: 1,
+  bindings: [{ action: "test.custom", key: "cmd+p" }],
+});
+
+beforeEach(() => {
+  vi.mocked(keyboard.loadKeybindings).mockResolvedValue(null);
+  // Ensure userAgent resolves to macos in jsdom
+  Object.defineProperty(navigator, "userAgent", {
+    value: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+    configurable: true,
+  });
+});
+
+describe("useKeyboardShortcuts", () => {
+  it("uses defaults when IPC returns null", async () => {
+    vi.mocked(keyboard.loadKeybindings).mockResolvedValue(null);
+    const handler = vi.fn();
+    const { result } = renderHook(() =>
+      useKeyboardShortcuts({ "worktree.selectNext": handler }),
+    );
+    // Wait for async IPC call
+    await act(async () => {});
+    const list = result.current.list();
+    expect(list.some((s) => s.action === "worktree.selectNext")).toBe(true);
+  });
+
+  it("uses user config when IPC returns valid JSON", async () => {
+    vi.mocked(keyboard.loadKeybindings).mockResolvedValue(validConfig);
+    const handler = vi.fn();
+    const { result } = renderHook(() =>
+      useKeyboardShortcuts({ "test.custom": handler }),
+    );
+    await act(async () => {});
+    const list = result.current.list();
+    expect(list.some((s) => s.action === "test.custom")).toBe(true);
+    // Default bindings should NOT be present since user config replaces them
+    expect(list.some((s) => s.action === "worktree.selectNext")).toBe(false);
+  });
+
+  it("falls back to defaults when JSON is invalid", async () => {
+    vi.mocked(keyboard.loadKeybindings).mockResolvedValue("not valid json{{{");
+    const { result } = renderHook(() => useKeyboardShortcuts({}));
+    await act(async () => {});
+    const list = result.current.list();
+    expect(list.some((s) => s.action === "worktree.selectNext")).toBe(true);
+  });
+
+  it("falls back to defaults when bindings array is empty", async () => {
+    vi.mocked(keyboard.loadKeybindings).mockResolvedValue(
+      JSON.stringify({ version: 1, bindings: [] }),
+    );
+    const { result } = renderHook(() => useKeyboardShortcuts({}));
+    await act(async () => {});
+    const list = result.current.list();
+    expect(list.some((s) => s.action === "worktree.selectNext")).toBe(true);
+  });
+
+  it("calls the correct action handler on matching keydown", async () => {
+    vi.mocked(keyboard.loadKeybindings).mockResolvedValue(null);
+    const handler = vi.fn();
+    renderHook(() =>
+      useKeyboardShortcuts({ "worktree.selectNext": handler }),
+    );
+    await act(async () => {});
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { metaKey: true, key: "]", bubbles: true }),
+      );
+    });
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("ignores keydown events for unregistered actions", async () => {
+    vi.mocked(keyboard.loadKeybindings).mockResolvedValue(null);
+    const handler = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ "worktree.selectNext": handler }));
+    await act(async () => {});
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { metaKey: true, key: "z", bubbles: true }),
+      );
+    });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("does not throw when action ID has no handler registered", async () => {
+    vi.mocked(keyboard.loadKeybindings).mockResolvedValue(null);
+    // No handlers provided — pressing a matching key should not throw
+    renderHook(() => useKeyboardShortcuts({}));
+    await act(async () => {});
+    expect(() => {
+      act(() => {
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", { metaKey: true, key: "]", bubbles: true }),
+        );
+      });
+    }).not.toThrow();
+  });
+});

--- a/src/features/keyboard/useKeyboardShortcuts.ts
+++ b/src/features/keyboard/useKeyboardShortcuts.ts
@@ -1,0 +1,64 @@
+import { useEffect, useRef, useState } from "react";
+import { keyboard } from "../../lib/desktop-client";
+import {
+  detectPlatform,
+  buildShortcutRegistry,
+  type ShortcutRegistry,
+} from "./shortcut-registry";
+import { getDefaultBindings } from "./default-keybindings";
+import { KeybindingsFileSchema } from "./keybindings-schema";
+
+export type ShortcutActionMap = Record<string, () => void>;
+
+function buildDefaultRegistry(): ShortcutRegistry {
+  const platform = detectPlatform();
+  return buildShortcutRegistry(getDefaultBindings(platform), platform);
+}
+
+export function useKeyboardShortcuts(actions: ShortcutActionMap): ShortcutRegistry {
+  const [registry, setRegistry] = useState<ShortcutRegistry>(buildDefaultRegistry);
+
+  // Keep actions ref up-to-date each render so the stable listener sees fresh handlers
+  const actionsRef = useRef(actions);
+  actionsRef.current = actions;
+
+  // Load user config once on mount and rebuild registry
+  useEffect(() => {
+    const platform = detectPlatform();
+    keyboard.loadKeybindings().then((raw) => {
+      let bindings = getDefaultBindings(platform);
+      if (raw !== null) {
+        try {
+          const parsed: unknown = JSON.parse(raw);
+          const result = KeybindingsFileSchema.safeParse(parsed);
+          if (result.success && result.data.bindings.length > 0) {
+            bindings = result.data.bindings;
+          } else {
+            console.warn("[keyboard] keybindings.json invalid or empty — using defaults");
+          }
+        } catch {
+          console.warn("[keyboard] keybindings.json failed to parse — using defaults");
+        }
+      }
+      setRegistry(buildShortcutRegistry(bindings, platform));
+    }).catch(() => {
+      // IPC unavailable (e.g. tests without full Electron) — keep defaults
+    });
+  }, []);
+
+  // Mount document-level keydown listener; re-registers when registry changes
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      const action = registry.resolve(event);
+      if (!action) return;
+      const fn = actionsRef.current[action];
+      if (!fn) return;
+      event.preventDefault();
+      fn();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [registry]);
+
+  return registry;
+}

--- a/src/features/terminals/TerminalPane.tsx
+++ b/src/features/terminals/TerminalPane.tsx
@@ -110,6 +110,11 @@ export function TerminalPane({
 		term.loadAddon(fitAddon);
 		term.open(containerRef.current);
 		term.attachCustomKeyEventHandler((event) => {
+			// When any dialog is open, let Escape bubble to its native Escape handler.
+			// Without this, xterm swallows Escape (a terminal control character) even
+			// when a Radix dialog is focused, preventing the dialog from closing.
+			if (event.key === "Escape" && document.querySelector('[role="dialog"]')) return false;
+
 			// Let registered global shortcuts bubble to the document-level handler.
 			// Returning false prevents xterm from calling preventDefault(), so the
 			// event propagates normally to our useKeyboardShortcuts document listener.

--- a/src/features/terminals/TerminalPane.tsx
+++ b/src/features/terminals/TerminalPane.tsx
@@ -5,6 +5,7 @@ import "xterm/css/xterm.css";
 import type { TerminalSession } from "../../../shared/models/terminal-session";
 import { terminals } from "../../lib/desktop-client";
 import { logRendererShellEvent } from "./shell-event-logger";
+import { useKeyboardRegistry } from "../keyboard/keyboard-context";
 
 type Props = {
 	session: TerminalSession;
@@ -29,6 +30,11 @@ export function TerminalPane({
 	const fitAddonRef = useRef<FitAddon | null>(null);
 	const unsubOutputRef = useRef<(() => void) | null>(null);
 	const paneInstanceIdRef = useRef(`pane_${session.id}_${Math.random().toString(36).slice(2, 8)}`);
+	const keyboardRegistry = useKeyboardRegistry();
+	// Use a ref so the stable xterm effect closure always sees the latest registry
+	// without needing to re-run (which would remount the entire xterm instance).
+	const keyboardRegistryRef = useRef(keyboardRegistry);
+	keyboardRegistryRef.current = keyboardRegistry;
 	const isLive = session.status === "running" || session.status === "idle";
 
 	/**
@@ -104,6 +110,13 @@ export function TerminalPane({
 		term.loadAddon(fitAddon);
 		term.open(containerRef.current);
 		term.attachCustomKeyEventHandler((event) => {
+			// Let registered global shortcuts bubble to the document-level handler.
+			// Returning false prevents xterm from calling preventDefault(), so the
+			// event propagates normally to our useKeyboardShortcuts document listener.
+			// Use the ref — not the closed-over value — so registry updates after the
+			// async IPC call are visible without re-running this effect.
+			if (keyboardRegistryRef.current?.matchesAny(event)) return false;
+
 			// Shift+Enter: send literal newline so agent TUIs can distinguish it from
 			// plain Enter. xterm maps keyCode 13 to '\r' regardless of shiftKey; we
 			// intercept and send '\n' instead, which raw-mode apps read as distinct.

--- a/src/lib/desktop-client.ts
+++ b/src/lib/desktop-client.ts
@@ -77,3 +77,7 @@ export const workspace: Ai14AllDesktopApi["workspace"] = {
 export const diagnostics: Ai14AllDesktopApi["diagnostics"] = {
 	logShellEvent: (event) => getDesktopClient().diagnostics.logShellEvent(event),
 };
+
+export const keyboard: Ai14AllDesktopApi["keyboard"] = {
+	loadKeybindings: () => getDesktopClient().keyboard.loadKeybindings(),
+};

--- a/tests/e2e/cumulative-flow.phase-9.test.ts
+++ b/tests/e2e/cumulative-flow.phase-9.test.ts
@@ -72,9 +72,9 @@ test.describe.serial("Cumulative flow — Phase 9", () => {
 		).toHaveAttribute("data-selected", "true", { timeout: 10_000 });
 	});
 
-	test("Cmd+/ opens the shortcuts help modal", async () => {
+	test("Cmd+Shift+/ opens the shortcuts help modal", async () => {
 		test.setTimeout(20_000);
-		await page.keyboard.press("Meta+/");
+		await page.keyboard.press("Meta+Shift+/");
 		await expect(
 			page.getByRole("dialog", { name: "Keyboard shortcuts" }),
 		).toBeVisible({ timeout: 8_000 });

--- a/tests/e2e/cumulative-flow.phase-9.test.ts
+++ b/tests/e2e/cumulative-flow.phase-9.test.ts
@@ -1,0 +1,90 @@
+import {
+	test,
+	expect,
+	_electron as electron,
+	type ElectronApplication,
+	type Page,
+} from "@playwright/test";
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createTestRepo, type TestRepo } from "./fixtures/create-test-repo";
+import { closeApp } from "./fixtures/close-app";
+
+let app: ElectronApplication | undefined;
+let page: Page;
+let testRepo: TestRepo;
+let persistedStateDir: string;
+
+test.beforeAll(async () => {
+	testRepo = createTestRepo();
+	persistedStateDir = realpathSync(mkdtempSync(join(tmpdir(), "ofa-phase9-")));
+	app = await electron.launch({
+		args: ["out/main/index.js"],
+		env: {
+			...process.env,
+			AI14ALL_E2E: "1",
+			AI14ALL_E2E_PICK_PATH: testRepo.repoPath,
+			AI14ALL_WORKSPACE_STATE_PATH: join(persistedStateDir, "workspace-state.json"),
+		},
+	});
+	page = await app.firstWindow({ timeout: 60_000 });
+}, 90_000);
+
+test.afterAll(async () => {
+	try {
+		await closeApp(app);
+	} finally {
+		rmSync(persistedStateDir, { recursive: true, force: true });
+		testRepo?.cleanup();
+	}
+});
+
+test.describe.serial("Cumulative flow — Phase 9", () => {
+	test("loads the repository and shows the worktree sidebar", async () => {
+		test.setTimeout(60_000);
+		await page.getByRole("button", { name: "Browse" }).click();
+		await expect(page.locator("#repo-path")).toHaveValue(testRepo.repoPath);
+		await page.getByRole("button", { name: "Load" }).click();
+		await expect(
+			page
+				.getByRole("navigation", { name: "Worktree sessions" })
+				.getByRole("button", { name: "feature-a", exact: true }),
+		).toBeVisible({ timeout: 15_000 });
+
+		// Select main worktree first so there is a "next" to navigate to
+		await page
+			.getByRole("navigation", { name: "Worktree sessions" })
+			.getByRole("button", { name: / main$/i })
+			.click();
+	});
+
+	test("Cmd+] switches to the next worktree", async () => {
+		test.setTimeout(30_000);
+		// Press the shortcut — document listener handles it regardless of focus
+		await page.keyboard.press("Meta+]");
+		// feature-a should now be the active worktree (the only other one).
+		// SessionSidebar sets data-selected="true" on the active worktree button.
+		await expect(
+			page
+				.getByRole("navigation", { name: "Worktree sessions" })
+				.getByRole("button", { name: "feature-a", exact: true }),
+		).toHaveAttribute("data-selected", "true", { timeout: 10_000 });
+	});
+
+	test("Cmd+/ opens the shortcuts help modal", async () => {
+		test.setTimeout(20_000);
+		await page.keyboard.press("Meta+/");
+		await expect(
+			page.getByRole("dialog", { name: "Keyboard shortcuts" }),
+		).toBeVisible({ timeout: 8_000 });
+	});
+
+	test("Escape closes the shortcuts help modal", async () => {
+		test.setTimeout(10_000);
+		await page.keyboard.press("Escape");
+		await expect(
+			page.getByRole("dialog", { name: "Keyboard shortcuts" }),
+		).not.toBeVisible({ timeout: 5_000 });
+	});
+});

--- a/tests/e2e/cumulative-flow.phase-9.test.ts
+++ b/tests/e2e/cumulative-flow.phase-9.test.ts
@@ -72,9 +72,9 @@ test.describe.serial("Cumulative flow — Phase 9", () => {
 		).toHaveAttribute("data-selected", "true", { timeout: 10_000 });
 	});
 
-	test("Cmd+Shift+/ opens the shortcuts help modal", async () => {
+	test("Cmd+Shift+P opens the shortcuts help modal", async () => {
 		test.setTimeout(20_000);
-		await page.keyboard.press("Meta+Shift+/");
+		await page.keyboard.press("Meta+Shift+P");
 		await expect(
 			page.getByRole("dialog", { name: "Keyboard shortcuts" }),
 		).toBeVisible({ timeout: 8_000 });

--- a/tests/unit/components/App-phase-6-shell.test.tsx
+++ b/tests/unit/components/App-phase-6-shell.test.tsx
@@ -110,6 +110,9 @@ vi.mock("../../../src/lib/desktop-client", () => ({
 	diagnostics: {
 		logShellEvent: vi.fn(() => Promise.resolve()),
 	},
+	keyboard: {
+		loadKeybindings: vi.fn().mockResolvedValue(null),
+	},
 }));
 
 import { App } from "../../../src/app/App";

--- a/tests/unit/components/App-refresh-changes.test.tsx
+++ b/tests/unit/components/App-refresh-changes.test.tsx
@@ -82,6 +82,9 @@ vi.mock("../../../src/lib/desktop-client", () => ({
 	diagnostics: {
 		logShellEvent: vi.fn(() => Promise.resolve()),
 	},
+	keyboard: {
+		loadKeybindings: vi.fn().mockResolvedValue(null),
+	},
 }));
 
 import { App } from "../../../src/app/App";

--- a/tests/unit/components/App-restore.test.tsx
+++ b/tests/unit/components/App-restore.test.tsx
@@ -77,6 +77,9 @@ vi.mock("../../../src/lib/desktop-client", () => ({
 	diagnostics: {
 		logShellEvent: vi.fn(() => Promise.resolve()),
 	},
+	keyboard: {
+		loadKeybindings: vi.fn().mockResolvedValue(null),
+	},
 }));
 
 import { App } from "../../../src/app/App";

--- a/tests/unit/components/App-review-degraded-state.test.tsx
+++ b/tests/unit/components/App-review-degraded-state.test.tsx
@@ -77,6 +77,9 @@ vi.mock("../../../src/lib/desktop-client", () => ({
 	diagnostics: {
 		logShellEvent: vi.fn(() => Promise.resolve()),
 	},
+	keyboard: {
+		loadKeybindings: vi.fn().mockResolvedValue(null),
+	},
 }));
 
 import { App } from "../../../src/app/App";

--- a/tests/unit/components/App-workspace-switching.test.tsx
+++ b/tests/unit/components/App-workspace-switching.test.tsx
@@ -75,6 +75,9 @@ vi.mock("../../../src/lib/desktop-client", () => ({
 	diagnostics: {
 		logShellEvent: diagnosticsLogMock,
 	},
+	keyboard: {
+		loadKeybindings: vi.fn().mockResolvedValue(null),
+	},
 }));
 
 import { App } from "../../../src/app/App";

--- a/tests/unit/components/App-worktree-lifecycle.test.tsx
+++ b/tests/unit/components/App-worktree-lifecycle.test.tsx
@@ -68,6 +68,9 @@ vi.mock("../../../src/lib/desktop-client", () => ({
 	diagnostics: {
 		logShellEvent: vi.fn(() => Promise.resolve()),
 	},
+	keyboard: {
+		loadKeybindings: vi.fn().mockResolvedValue(null),
+	},
 }));
 
 import { App } from "../../../src/app/App";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
 	test: {
 		environment: "jsdom",
 		globals: true,
-		include: ["tests/unit/**/*.test.{ts,tsx}"],
+		include: ["tests/unit/**/*.test.{ts,tsx}", "src/**/*.test.{ts,tsx}"],
 		setupFiles: ["./tests/setup.ts"],
 	},
 });


### PR DESCRIPTION
## Summary

- Full keyboard shortcut registry with platform-aware key parsing and O(1) lookup
- 17 default bindings covering worktree, workspace, terminal, layout, review and app actions
- `ShortcutsHelpModal` (⌘⇧P) showing all shortcuts grouped with bordered sections, top-right close button, and space-between label/key layout
- xterm integration: global shortcuts bubble through the terminal; Escape closes dialogs even when terminal is focused
- User-overridable keybindings via `keybindings.json` in Electron userData
- HMR full-reload on `default-keybindings.ts` changes so dev mode reflects edits instantly

## Default shortcuts

| Action | macOS |
|--------|-------|
| Next/Prev worktree | ⌘] / ⌘[ |
| Add worktree | ⌘N |
| Next/Prev workspace | ⌘⇧] / ⌘⇧[ |
| New terminal | ⌘T |
| Close terminal | ⌘⇧W |
| Next/Prev terminal | ⌘⇧D / ⌘⇧A |
| Toggle split | ⌘D |
| Toggle top band | ⌘⇧B |
| Toggle sidebar | ⌘B |
| Review files/changes/commits | ⌘1 / ⌘2 / ⌘3 |
| Open workspace picker | ⌘O |
| Show shortcuts | ⌘⇧P |

## Test plan

- [ ] Open app with `pnpm dev`, verify ⌘] / ⌘[ switch worktrees with terminal focused
- [ ] ⌘⇧P opens shortcuts modal; Escape closes it
- [ ] ⌘B toggles sidebar; ⌘⇧B toggles top band
- [ ] ⌘⇧D / ⌘⇧A cycle through terminals
- [ ] Edit `default-keybindings.ts` in dev mode — app reloads automatically
- [ ] E2E phase-9 tests pass