### PR TITLE
feat(terminals): terminal tab auto-focus, VS Code split behavior, scroll position fix

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -398,8 +398,36 @@ export function App() {
 		onOpen: openEditorForFile,
 	});
 
+	const [terminalFocusSignal, setTerminalFocusSignal] = useState(0);
+
 	function selectActiveProcess(processId: string) {
 		if (!activeWorktree) return;
+
+		// VS Code-style split mode behavior:
+		// - In split mode, clicking a process not in either slot → exit split (show alone)
+		// - In single mode, clicking a process that still has a slot assigned → restore split
+		if (activeSession?.terminalLayoutMode === "split") {
+			if (
+				activeSession.splitLeftProcessId !== processId &&
+				activeSession.splitRightProcessId !== processId
+			) {
+				dispatch({
+					type: "session/setTerminalLayoutMode",
+					worktreeId: activeWorktree.id,
+					layoutMode: "single",
+				});
+			}
+		} else if (
+			activeSession?.splitLeftProcessId === processId ||
+			activeSession?.splitRightProcessId === processId
+		) {
+			dispatch({
+				type: "session/setTerminalLayoutMode",
+				worktreeId: activeWorktree.id,
+				layoutMode: "split",
+			});
+		}
+
 		dispatch({
 			type: "session/selectProcess",
 			worktreeId: activeWorktree.id,
@@ -421,6 +449,25 @@ export function App() {
 			type: "session/clearSessionAgentAttention",
 			worktreeId: activeWorktree.id,
 		});
+		setTerminalFocusSignal((n) => n + 1);
+
+		// Focus the terminal synchronously so keyboard input lands immediately.
+		// useEffect fires after paint (too late when Playwright or fast users
+		// type right after clicking a tab). We look up the xterm textarea via
+		// the data-terminal-session-id attribute set by TerminalPane and the
+		// stable xterm-helper-textarea class used throughout the E2E suite.
+		const terminalSessionId =
+			workspaceStateRef.current.processSessionsById[processId]
+				?.terminalSessionId;
+		if (terminalSessionId) {
+			const pane = document.querySelector(
+				`[data-terminal-session-id="${terminalSessionId}"]`,
+			);
+			const textarea = pane?.querySelector(
+				".xterm-helper-textarea",
+			) as HTMLTextAreaElement | null;
+			textarea?.focus({ preventScroll: true });
+		}
 	}
 
 	const {
@@ -1052,6 +1099,32 @@ export function App() {
 			const nextProcessId = processes[nextIdx]?.id;
 			if (!nextProcessId) return;
 			e.preventDefault();
+
+			// VS Code-style split mode behavior (same as selectActiveProcess):
+			// - In split mode, navigating to a process not in either slot → single view
+			// - In single mode, navigating to a process with a slot assigned → restore split
+			if (session.terminalLayoutMode === "split") {
+				if (
+					session.splitLeftProcessId !== nextProcessId &&
+					session.splitRightProcessId !== nextProcessId
+				) {
+					dispatch({
+						type: "session/setTerminalLayoutMode",
+						worktreeId: currentWorktreeId,
+						layoutMode: "single",
+					});
+				}
+			} else if (
+				session.splitLeftProcessId === nextProcessId ||
+				session.splitRightProcessId === nextProcessId
+			) {
+				dispatch({
+					type: "session/setTerminalLayoutMode",
+					worktreeId: currentWorktreeId,
+					layoutMode: "split",
+				});
+			}
+
 			dispatch({
 				type: "session/selectProcess",
 				worktreeId: currentWorktreeId,
@@ -1073,6 +1146,7 @@ export function App() {
 				type: "session/clearSessionAgentAttention",
 				worktreeId: currentWorktreeId,
 			});
+			setTerminalFocusSignal((n) => n + 1);
 		},
 		[dispatch],
 	);
@@ -1350,6 +1424,7 @@ export function App() {
 						visibleProcessIds={visibleProcessIds}
 						sessions={sessions}
 						orderedSessions={orderedSessions}
+						terminalFocusSignal={terminalFocusSignal}
 						dispatch={dispatch}
 						handleAddAdHoc={handleAddAdHoc}
 						selectActiveProcess={selectActiveProcess}

--- a/src/app/components/TerminalPanel.tsx
+++ b/src/app/components/TerminalPanel.tsx
@@ -18,6 +18,7 @@ type Props = {
 	visibleProcessIds: readonly string[];
 	sessions: TerminalSession[];
 	orderedSessions: TerminalSession[];
+	terminalFocusSignal: number;
 	dispatch: (action: WorkspaceAction) => void;
 	handleAddAdHoc: () => Promise<void>;
 	selectActiveProcess: (processId: string) => void;
@@ -45,6 +46,7 @@ export function TerminalPanel(props: Props): React.ReactElement | null {
 		visibleProcessIds,
 		sessions,
 		orderedSessions,
+		terminalFocusSignal,
 		dispatch,
 		handleAddAdHoc,
 		selectActiveProcess,
@@ -132,18 +134,23 @@ export function TerminalPanel(props: Props): React.ReactElement | null {
 				{orderedSessions.map((session) => {
 					const process =
 						findProcessByTerminalSessionId(session.id)?.process ?? null;
+					const visible =
+						session.worktreeId === activeWorktree?.id &&
+						visibleProcessIds.some(
+							(processId) =>
+								workspaceState.processSessionsById[processId]
+									?.terminalSessionId === session.id,
+						);
 					return (
 						<TerminalPane
 							key={session.id}
 							session={session}
-							visible={
-								session.worktreeId === activeWorktree?.id &&
-								visibleProcessIds.some(
-									(processId) =>
-										workspaceState.processSessionsById[processId]
-											?.terminalSessionId === session.id,
-								)
+							visible={visible}
+							focused={
+								visible &&
+								process?.id === activeSession?.activeProcessSessionId
 							}
+							focusSignal={terminalFocusSignal}
 							onTitleChange={(title) => {
 								if (!process || process.origin !== "adHoc") return;
 								const nextLabel = normalizeTerminalTitle(title);

--- a/src/features/terminals/components/TerminalPane.tsx
+++ b/src/features/terminals/components/TerminalPane.tsx
@@ -54,6 +54,13 @@ export function TerminalPane({
 		`pane_${session.id}_${Math.random().toString(36).slice(2, 8)}`,
 	);
 	const isLive = session.status === "running" || session.status === "idle";
+	/**
+	 * Viewport row offset saved the moment this pane becomes hidden.
+	 * Restored after fit() when the pane becomes visible again, so that
+	 * output arriving while hidden (which auto-scrolls xterm internally)
+	 * does not clobber the user's scroll position.
+	 */
+	const savedScrollRef = useRef<number | null>(null);
 
 	const [findOpen, setFindOpen] = useState(false);
 	const [findQuery, setFindQuery] = useState("");
@@ -149,7 +156,7 @@ export function TerminalPane({
 
 		const term = new Terminal({
 			cursorBlink: true,
-			scrollback: 2000,
+			scrollback: 10_000,
 			screenReaderMode: true,
 			fontSize: 12,
 			fontFamily:
@@ -301,16 +308,39 @@ export function TerminalPane({
 		});
 	}, [visible, session.id]);
 
-	// Fit + resize PTY when the pane becomes visible.
+	// Save scroll position when the pane is hidden, restore it when shown.
+	//
+	// Why not read viewportY at show-time (the old fitPreservingScroll approach)?
+	// While hidden, the PTY keeps running and xterm auto-scrolls its internal
+	// viewportY to keep the cursor visible. By the time the pane is shown again
+	// the buffer position has already moved to the bottom, so reading it there
+	// restores the wrong place. Capturing it on hide (before any new data shifts
+	// it) and replaying it on show gives the correct user-intended position.
 	useEffect(() => {
-		if (!visible || !isLive) return;
+		if (!visible) {
+			// Capture the position the user was at before we hide.
+			savedScrollRef.current =
+				termRef.current?.buffer.active.viewportY ?? null;
+			return;
+		}
+
+		if (!isLive) return;
 		const term = termRef.current;
 		const fitAddon = fitAddonRef.current;
 		if (!term || !fitAddon) return;
 
-		fitPreservingScroll(term, fitAddon);
+		fitAddon.fit();
 		terminals.resize(session.id, term.cols, term.rows).catch(() => undefined);
-	}, [isLive, visible, session.id, fitPreservingScroll]);
+
+		const saved = savedScrollRef.current;
+		if (saved !== null) {
+			// Clamp to the valid range — baseY is the maximum scrollable offset.
+			const target = Math.min(saved, term.buffer.active.baseY);
+			const delta = target - term.buffer.active.viewportY;
+			if (delta !== 0) term.scrollLines(delta);
+		}
+		savedScrollRef.current = null;
+	}, [isLive, visible, session.id]);
 
 	// Auto-focus the xterm instance when this pane becomes the active terminal,
 	// so the user can type immediately without an extra click.

--- a/src/features/terminals/components/TerminalPane.tsx
+++ b/src/features/terminals/components/TerminalPane.tsx
@@ -17,6 +17,15 @@ const FIND_DECORATIONS = {
 type Props = {
 	session: TerminalSession;
 	visible: boolean;
+	/** Boolean: is this the currently active pane? */
+	focused?: boolean;
+	/**
+	 * Monotonically-increasing counter that bumps on every terminal selection
+	 * (tab click or keyboard shortcut). Including it in the effect dep array
+	 * ensures focus is reclaimed even when `focused` doesn't change (e.g.
+	 * clicking the already-active tab after focus moved to the tab bar).
+	 */
+	focusSignal?: number;
 	onTitleChange?: (title: string) => void;
 	onActivate?: () => void;
 };
@@ -29,6 +38,8 @@ type Props = {
 export function TerminalPane({
 	session,
 	visible,
+	focused,
+	focusSignal,
 	onTitleChange,
 	onActivate,
 }: Props) {
@@ -300,6 +311,18 @@ export function TerminalPane({
 		fitPreservingScroll(term, fitAddon);
 		terminals.resize(session.id, term.cols, term.rows).catch(() => undefined);
 	}, [isLive, visible, session.id, fitPreservingScroll]);
+
+	// Auto-focus the xterm instance when this pane becomes the active terminal,
+	// so the user can type immediately without an extra click.
+	// focusSignal is included in deps so the effect re-runs on every selection
+	// event — even when focused stays true (e.g. re-clicking the active tab
+	// after focus drifted to the tab bar button).
+	// Skip if the find bar is open — the find input holds focus in that case.
+	useEffect(() => {
+		if (!focused || !visible || findOpen) return;
+		termRef.current?.focus();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [focusSignal, focused, visible, findOpen]);
 
 	// Resize on container dimension changes via ResizeObserver.
 	useEffect(() => {

--- a/src/features/terminals/components/TerminalTabs.tsx
+++ b/src/features/terminals/components/TerminalTabs.tsx
@@ -77,7 +77,6 @@ export function TerminalTabs({
 		<Tooltip.Provider delayDuration={150}>
 			<Tabs.Root
 				value={activeProcessId ?? undefined}
-				onValueChange={onSelect}
 				className="shell-terminal-tabs"
 			>
 				<div className="shell-terminal-tabs__bar">
@@ -93,7 +92,21 @@ export function TerminalTabs({
 								);
 								return (
 									<ContextMenu.Root key={process.id}>
-										<ContextMenu.Trigger className="shell-terminal-tabs__item">
+										<ContextMenu.Trigger
+											className="shell-terminal-tabs__item"
+											onMouseDown={(e) => {
+												// Left-click only: prevent the browser from moving
+												// keyboard focus to the tab button. This keeps
+												// focus in the terminal so typing works immediately.
+												if (e.button === 0) e.preventDefault();
+											}}
+											onClick={(e) => {
+												// Fire onSelect for every left-click, including
+												// re-clicks of the already-active tab (Radix
+												// onValueChange skips those since value doesn't change).
+												if (e.button === 0) onSelect(process.id);
+											}}
+										>
 											<Tabs.Trigger
 												value={process.id}
 												className="shell-terminal-tab"

--- a/tests/e2e/terminal-tab-focus.test.ts
+++ b/tests/e2e/terminal-tab-focus.test.ts
@@ -1,0 +1,193 @@
+import {
+	test,
+	expect,
+	_electron as electron,
+	type ElectronApplication,
+	type Page,
+} from "@playwright/test";
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createTestRepo, type TestRepo } from "./fixtures/create-test-repo";
+import { closeApp } from "./fixtures/close-app";
+
+let app: ElectronApplication | undefined;
+let page: Page;
+let testRepo: TestRepo;
+let persistedStateDir: string;
+
+test.beforeAll(async () => {
+	testRepo = createTestRepo();
+	persistedStateDir = realpathSync(
+		mkdtempSync(join(tmpdir(), "ofa-tab-focus-")),
+	);
+	app = await electron.launch({
+		args: ["out/main/index.js"],
+		env: {
+			...process.env,
+			AI14ALL_E2E: "1",
+			AI14ALL_WORKSPACE_STATE_PATH: join(
+				persistedStateDir,
+				"workspace-state.json",
+			),
+		},
+	});
+	page = await app.firstWindow({ timeout: 60_000 });
+}, 90_000);
+
+test.afterAll(async () => {
+	try {
+		await closeApp(app);
+	} finally {
+		rmSync(persistedStateDir, { recursive: true, force: true });
+		testRepo?.cleanup();
+	}
+});
+
+/**
+ * Wait for a shell tab to be visible and for its xterm pane to be ready
+ * (i.e. the textarea exists — xterm creates it on open()).
+ */
+async function waitForShellTab(name: RegExp, timeout = 15_000) {
+	await expect(page.getByRole("tab", { name })).toBeVisible({ timeout });
+	await page.locator(".xterm-helper-textarea").first().waitFor({
+		state: "attached",
+		timeout,
+	});
+}
+
+/**
+ * Type a command into whichever element currently has keyboard focus and
+ * press Enter. Does NOT explicitly focus the xterm textarea — the test relies
+ * on the app's auto-focus behavior to route keystrokes to the right terminal.
+ */
+async function typeIntoFocusedElement(text: string) {
+	await page.keyboard.type(text);
+	await page.keyboard.press("Enter");
+}
+
+/**
+ * Locator for the accessibility tree of the currently visible terminal pane.
+ * Panes that are hidden use aria-hidden="true"; the active pane uses "false".
+ * In split mode both panes are visible — this returns the first visible one.
+ */
+function visibleTerminalTree() {
+	return page.locator('[aria-hidden="false"].shell-terminal-pane .xterm-accessibility-tree').first();
+}
+
+test.describe.serial("Terminal tab auto-focus", () => {
+	test.describe.configure({ timeout: 120_000 });
+
+	test("focuses the terminal immediately after clicking its tab — single mode", async () => {
+		// ── Setup ──────────────────────────────────────────────────────────────
+		await page.locator("#repo-path").fill(testRepo.repoPath);
+		await page.getByRole("button", { name: "Load" }).click();
+		await waitForShellTab(/shell 1/i);
+
+		// Confirm shell 1 is interactive (explicit focus just for baseline).
+		const textarea = page.locator(".xterm-helper-textarea").first();
+		await textarea.focus();
+		const baseline = `BASELINE_${Date.now()}`;
+		await page.keyboard.type(`echo ${baseline}`);
+		await page.keyboard.press("Enter");
+		await expect(visibleTerminalTree()).toContainText(baseline, {
+			timeout: 10_000,
+		});
+
+		// ── Add shell 2 ────────────────────────────────────────────────────────
+		await page.getByRole("button", { name: "Add shell" }).click();
+		await waitForShellTab(/shell 2/i);
+
+		// Shell 2 becomes active after creation — confirm it is visible/active.
+		await expect(
+			page.getByRole("tab", { name: /shell 2/i }),
+		).toHaveAttribute("data-state", "active");
+
+		// ── Click shell 1 tab (no explicit textarea focus) ─────────────────────
+		await page.getByRole("tab", { name: /shell 1/i }).click();
+		await expect(
+			page.getByRole("tab", { name: /shell 1/i }),
+		).toHaveAttribute("data-state", "active");
+
+		// Type WITHOUT explicitly focusing the textarea.
+		// If auto-focus works, this text goes to shell 1's PTY.
+		const marker1 = `AUTOFOCUS_TAB_${Date.now()}`;
+		await typeIntoFocusedElement(`echo ${marker1}`);
+
+		await expect(visibleTerminalTree()).toContainText(marker1, {
+			timeout: 10_000,
+		});
+
+		// ── Click shell 2 tab (no explicit focus) ──────────────────────────────
+		await page.getByRole("tab", { name: /shell 2/i }).click();
+		await expect(
+			page.getByRole("tab", { name: /shell 2/i }),
+		).toHaveAttribute("data-state", "active");
+
+		const marker2 = `AUTOFOCUS_TAB2_${Date.now()}`;
+		await typeIntoFocusedElement(`echo ${marker2}`);
+
+		// Shell 2's pane is now visible — the marker should appear in its tree.
+		await expect(visibleTerminalTree()).toContainText(marker2, {
+			timeout: 10_000,
+		});
+	});
+
+	test("re-clicking the already-active tab restores focus to the terminal", async () => {
+		// Shell 2 should still be active from the previous test.
+		await expect(
+			page.getByRole("tab", { name: /shell 2/i }),
+		).toHaveAttribute("data-state", "active");
+
+		// Click somewhere outside the terminal to move focus away from it.
+		// Clicking the "Add shell" button moves keyboard focus to that button.
+		await page.getByRole("button", { name: "Add shell" }).focus();
+
+		// Re-click the already-active tab. focused prop does not change, so only
+		// focusSignal can trigger the re-focus.
+		await page.getByRole("tab", { name: /shell 2/i }).click();
+
+		const marker = `REFOCUS_SAME_TAB_${Date.now()}`;
+		await typeIntoFocusedElement(`echo ${marker}`);
+
+		await expect(visibleTerminalTree()).toContainText(marker, {
+			timeout: 10_000,
+		});
+	});
+
+	test("focuses the correct terminal after split-mode tab switch exits to single", async () => {
+		// Add shell 3 so we have enough terminals for a split.
+		await page.getByRole("button", { name: "Add shell" }).click();
+		await waitForShellTab(/shell 3/i);
+
+		// Enable split mode via the toggle button.
+		await page
+			.getByRole("button", { name: /enable split shells/i })
+			.click();
+
+		// Assign shells 2 and 3 to the split slots via context menu.
+		await page
+			.getByRole("tab", { name: /shell 2/i })
+			.click({ button: "right" });
+		await page.getByRole("menuitem", { name: /show in split left/i }).click();
+
+		await page
+			.getByRole("tab", { name: /shell 3/i })
+			.click({ button: "right" });
+		await page.getByRole("menuitem", { name: /show in split right/i }).click();
+
+		// Now click shell 1's tab — it is NOT in either split slot, so the app
+		// should exit split mode and show shell 1 alone.
+		await page.getByRole("tab", { name: /shell 1/i }).click();
+		await expect(
+			page.getByRole("button", { name: /enable split shells/i }),
+		).toBeVisible({ timeout: 5_000 });
+
+		const marker = `SPLIT_EXIT_FOCUS_${Date.now()}`;
+		await typeIntoFocusedElement(`echo ${marker}`);
+
+		await expect(visibleTerminalTree()).toContainText(marker, {
+			timeout: 10_000,
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- **Auto-focus on tab click / keyboard shortcut** — clicking any tab (including re-clicking the active one) immediately focuses the xterm textarea so the user can type without an extra click. Keyboard shortcuts (`terminal.selectNext/Prev`) now also trigger focus.
- **VS Code-style split mode navigation** — clicking or shortcutting to a terminal that is not assigned to any split slot exits split mode and shows it alone; navigating to one that has a slot restores split mode. This applies to both tab clicks and keyboard shortcuts.
- **Re-click of active tab now works** — Radix `onValueChange` is skipped for re-clicks (value didn't change). Moved selection handling to `onClick` on the `ContextMenu.Trigger` wrapper so every left-click fires `onSelect`, including same-tab re-clicks.
- **Scroll position preserved on tab switch** — while a pane is hidden the PTY keeps running and xterm auto-scrolls its internal `viewportY`; reading it at show-time returned the wrong (bottom) position. Now `viewportY` is captured the moment a pane hides and restored (clamped to `baseY`) after `fit()` when shown again.
- **Increased scrollback buffer** — raised from 2,000 to 10,000 lines so long AI conversations don't lose history.

## Changed files

| File | Change |
|------|--------|
| `src/app/App.tsx` | `selectActiveProcess` with VS Code split logic + sync DOM focus; same logic added to `terminal.selectNext/Prev` shortcut handler |
| `src/app/components/TerminalPanel.tsx` | Pass `focused` + `focusSignal` props to `TerminalPane` |
| `src/features/terminals/components/TerminalPane.tsx` | `savedScrollRef` save/restore, `scrollback: 10_000`, auto-focus `useEffect` |
| `src/features/terminals/components/TerminalTabs.tsx` | `onClick` on `ContextMenu.Trigger` replaces `onValueChange`; `onMouseDown` prevents focus steal |
| `tests/e2e/terminal-tab-focus.test.ts` | New E2E suite: single-mode focus, same-tab re-focus, split-exit focus |

## Test plan

- [x] All 3 new E2E tests pass (`terminal-tab-focus.test.ts`)
- [x] Full E2E suite: 99 passed, 0 new failures (2 pre-existing flaky tests passed on retry)
- [ ] Manual: click tab → type immediately (no extra click needed)
- [ ] Manual: re-click active tab after clicking elsewhere → typing still goes to terminal
- [ ] Manual: terminals 1+2 in split, use shortcut to switch to terminal 3 → exits split
- [ ] Manual: scroll up in terminal A, switch to B, come back to A → scroll position preserved
- [ ] Manual: generate >2000 lines of output → can still scroll back through history