### PR TITLE
docs: collect improvement specs (onboarding, TUI theme, gallery smoke spec)

### DIFF
--- a/docs/superpowers/specs/2026-05-31-onboarding-wizard-design.md
+++ b/docs/superpowers/specs/2026-05-31-onboarding-wizard-design.md
@@ -1,5 +1,9 @@
 # Onboarding Wizard Design
 
+> **Superseded** by [2026-06-10-onboarding-flow-design.md](./2026-06-10-onboarding-flow-design.md).
+> This dialog-based feature tour was implemented on the unmerged `UI-overhaul` branch
+> and is replaced by a full-screen narrative stepper.
+
 ## Summary
 
 A 5-step guided walkthrough dialog shown on first run, introducing intermediate developers to ai-14all's core concepts (workspaces, worktrees, terminals, code review) before they load a repository. Re-accessible from the Shortcuts Help modal.

--- a/docs/superpowers/specs/2026-06-10-onboarding-flow-design.md
+++ b/docs/superpowers/specs/2026-06-10-onboarding-flow-design.md
@@ -1,0 +1,164 @@
+# Onboarding Flow Design
+
+> Supersedes [2026-05-31-onboarding-wizard-design.md](./2026-05-31-onboarding-wizard-design.md)
+> (dialog-based 5-step feature tour, implemented on the unmerged `UI-overhaul` branch).
+> This design replaces the feature-tour framing with a narrative pitch in a full-screen
+> stepper, while inheriting the proven mechanics from that implementation: the
+> `localStorage` completion flag, the ShortcutsHelp restart entry, and embedding
+> `RepositoryInput` in the final step.
+
+## Summary
+
+A full-screen 4-step narrative stepper shown once on first launch, before any
+repository is loaded. It introduces ai-14all, names the problem (an unmanaged agent
+swarm), shows how the app solves it, and ends by loading the user's first repository.
+Slogan: **"One for all-mighty agents. Go beyond!"**
+
+## Target User
+
+Engineers who already run AI coding agents (Claude, Codex, other agent CLIs) and are
+evaluating whether ai-14all is worth adopting. The flow sells the why before the how —
+it is a pitch, not a feature tour.
+
+## Trigger & Gating
+
+- **First-run detection:** `localStorage.getItem("ai14all:onboarding-completed")` —
+  if `null`, the app enters a new `startupMode === "onboarding"` before resolving to
+  `"prompt"` / `"ready"` in `App.tsx`.
+- **Skip:** visible on steps 1–3; sets the flag to `"true"` and continues normal
+  startup resolution (restore prompt or bare `RepositoryInput`).
+- **Completion:** the flag is set when the user submits a repository path on step 4
+  (before `handleLoadPath` fires).
+- **Replay:** a "Welcome to ai-14all" button in `ShortcutsHelp` reopens the stepper
+  at any time as a replay: steps 1–3 only, with a Close button instead of the
+  repository form (the user already has a repo loaded; clearing it would be hostile).
+
+## Steps
+
+### Step 1 — Introduce
+
+- Wordmark "ai-14all" with the slogan: **"One for all-mighty agents. Go beyond!"**
+- Supporting line: "Run Claude, Codex, or any agent CLI side by side — each in its
+  own isolated Git worktree."
+- Read-only. CTA: Next.
+
+### Step 2 — The Problem
+
+- Headline: **"One agent is easy. An agent swarm is chaos."**
+- Three pain bullets, framed as what happens when you run a swarm without structure:
+  - The swarm clobbers itself — agents overwrite each other's files on a shared
+    checkout.
+  - You lose track of the swarm — which agent is working, which is stuck waiting
+    on you.
+  - Reviewing the swarm's output means juggling terminals and an IDE.
+- Read-only.
+
+### Step 3 — The Solution
+
+- Three beats mirroring the pains, each with an icon (lucide, matching the app's
+  icon set):
+  - **Isolation** — every session automatically gets its own Git worktree and
+    branch; agents never collide.
+  - **Attention** — the sidebar shows who's working, who's blocked on you, who's
+    done; agents self-report over the built-in MCP server.
+  - **Review in place** — inspect diffs, comment, keep or discard without leaving
+    the window.
+- Footnote line: live per-agent token telemetry for Claude and Codex.
+- Read-only.
+
+### Step 4 — Go Beyond
+
+- Headline: "Go beyond. Load your first repository."
+- Embeds the existing `<RepositoryInput>` component (path field, Browse, Load),
+  inheriting its error display.
+- Interactive — submitting a path sets the completion flag and lands the user in
+  the normal app.
+- No Skip on this step (the only exits are Back or loading a repo); the Load action
+  is the finish.
+
+## Component Architecture
+
+### New files
+
+- `src/features/onboarding/OnboardingStepper.tsx` — the full-screen stepper.
+
+### Structure
+
+```
+<main className="shell-app shell-app--setup shell-app--onboarding">
+  {/* Step content — conditional render by stepIndex (0–3) */}
+  <StepIntroduce />   | stepIndex === 0
+  <StepProblem />     | stepIndex === 1
+  <StepSolution />    | stepIndex === 2
+  <StepGoBeyond />    | stepIndex === 3   (hidden in replay mode)
+  <footer>
+    <BackButton />    {/* hidden on step 0 */}
+    <StepDots />      {/* 4 dots; 3 in replay mode */}
+    <SkipLink />      {/* steps 0–2 only; "Close" in replay mode */}
+    <NextButton />    {/* hidden on step 3 — RepositoryInput's Load is the finish */}
+  </footer>
+</main>
+```
+
+Step content is rendered as functions within the component — each step is small
+markup, no separate files.
+
+### Integration
+
+- `App.tsx`: `startupMode` gains an `"onboarding"` value. The startup handshake in
+  `use-startup-restore.ts` checks the completion flag first; when absent it resolves
+  to `"onboarding"` instead of `"prompt"`/`"ready"`. Finish/skip transitions to the
+  mode the handshake would otherwise have produced.
+- Props: `onLoadPath` (passed through to `RepositoryInput` on step 4), `onDone`
+  (skip/finish/close), `replay: boolean`.
+- `ShortcutsHelp.tsx` gets a "Welcome to ai-14all" button that opens the stepper in
+  replay mode (it does not clear the flag).
+
+## Navigation & Input
+
+- Next / Back buttons, dot progress indicator (decorative, not interactive).
+- Keyboard: `←`/`→` to navigate, `Enter` advances (except inside the path input on
+  step 4), `Esc` skips on steps 1–3 and does nothing on step 4 (closes, in replay
+  mode).
+
+## Styling
+
+- Reuses the `shell-app--setup` full-screen treatment; content column centered,
+  max-width ~560px.
+- Step transitions: horizontal slide + fade (`translateX` + `opacity`, 200ms ease);
+  instant switch under `prefers-reduced-motion`.
+- Step dots: 8px circles, `--accent` active (1.25x scale), `--panel-border` inactive.
+- Theme-aware via existing CSS variables (`data-theme`) — dark, light, and warm.
+- Illustrations, if any, are inline HTML/CSS using existing variables — no external
+  image assets.
+
+## State Management
+
+- `useState<number>` for `stepIndex`.
+- `localStorage` for `"ai14all:onboarding-completed"` (same key as the superseded
+  implementation, so users of `UI-overhaul` builds are not re-onboarded).
+- No new context providers, reducers, or persistence layers.
+
+## Accessibility
+
+- The stepper is a full-screen `<main>`, not a dialog — no focus trap needed; focus
+  moves to the step heading on step change.
+- Step changes announced via `aria-live="polite"` on the content container.
+- All controls keyboard-accessible; dots are decorative.
+
+## Testing
+
+- **Unit:** startup-mode resolution (flag absent → `"onboarding"`; flag set → normal
+  flow), skip/finish set the flag, replay mode hides step 4 and never clears the flag.
+- **E2E (Playwright):** fresh profile shows the stepper; completing step 4 loads a
+  repository; relaunch with the flag set goes straight to the normal startup flow.
+  Existing e2e suites that assume no onboarding must clear/set the flag in setup
+  (the `UI-overhaul` branch did the same in its flush-layout suite).
+
+## Scope Boundaries
+
+- **In scope:** 4-step full-screen stepper, localStorage gating, replay from
+  ShortcutsHelp, slogan placement.
+- **Out of scope:** in-app coach marks or guided tours after a repo loads, animated
+  illustrations or video, per-step analytics/telemetry, version-gated "What's New"
+  flows, Windows/Intel considerations.

--- a/docs/tui-css-spec.md
+++ b/docs/tui-css-spec.md
@@ -1,0 +1,466 @@
+# Spec: Terminal UI Aesthetic on the shadcn Token System
+
+**Status:** Implemented through PR F (dark launch) on `feat/terminal-ui-theme` — the
+`tui` theme is feature-complete and toggleable in-app; only PR G (flatten, gated on
+visual sign-off) remains. As-built deviations are recorded in §12.
+**Branch context:** follow-up to `feat/shadcn-primitives-migration`
+**Source studied:** [WebTUI](https://webtui.ironclad.sh/start/intro/) (`@webtui/css` v0.1.7 — actual shipped CSS, not just docs)
+
+## 1. Goal
+
+The shadcn migration gave us a clean token + primitive layer, but the styling is stock
+"new-york" — soft radii, layered shadows, alpha-blended hovers, zoom/fade animations.
+This spec restyles the app to a Terminal UI aesthetic **without leaving the shadcn
+standard**: same token names (`--background`, `--primary`, `--radius`, …), same
+`components.json`, same cva-variant component structure, same Tailwind v4 `@theme inline`
+block. WebTUI is the reference for *what terminal aesthetics actually are in CSS*; shadcn
+remains the architecture.
+
+## 2. What WebTUI actually does (findings)
+
+Reading `@webtui/css` source, the TUI look reduces to six concrete techniques:
+
+### 2.1 The character grid: `ch` and `lh` are the only units
+Everything is sized in character cells: padding `1lh 1ch`, control heights `1lh` / `3lh`,
+input `min-width: 24ch`, dialog `max-width: 64ch; max-height: 24lh`. Nothing is sized in
+px/rem except border widths. This — more than color — is what makes it read as a terminal:
+elements snap to a text grid.
+
+### 2.2 A stepped color ladder, no alpha
+```css
+:root {
+  --background0: #fff; --background1: #ddd; --background2: #bbb; --background3: #999;
+  --foreground0: #000; --foreground1: #444; --foreground2: #888;
+}
+```
+Four background steps, three foreground steps. State changes (hover, emphasis) move one
+step on the ladder — they never blend with alpha (`bg-primary/90`-style hovers don't
+exist). Borders are full-opacity ladder colors, never `rgba(255,255,255,0.1)`.
+
+### 2.3 Zero elevation: no shadows, no blur, no gradient decoration
+There is not a single `box-shadow` in the library. "Elevation" is a background ladder
+step plus a solid border. Gradients appear only as a *drawing tool* (see 2.4), never as
+decoration.
+
+### 2.4 Box-drawing borders: the border lives in the middle of the padding cell
+The signature `box-="square|round|double"` utility pads the element by one cell
+(`padding: 1lh 1ch`) and draws the border on a centered pseudo-element inset by half a
+cell — exactly where a `┌─┐` box-drawing character would render:
+
+```css
+[box-] { position: relative; isolation: isolate; padding: 1lh 1ch; }
+[box-]::before {
+  content: ""; position: absolute; top: 50%; left: 50%; translate: -50% -50%;
+  width: calc(100% - 1ch - var(--box-border-width));
+  height: calc(100% - 1lh - var(--box-border-width));
+  border: solid var(--box-border-width) var(--box-border-color);
+  z-index: -1;
+}
+[box-][shear-="top"] { padding-top: 0; }  /* lets a child <span> sit ON the border line */
+```
+`shear-` collapses the padding so a title row overlaps the border — the classic
+`┌─ Title ─────┐` framed-pane look. `double` adds a second pseudo-element border.
+
+### 2.5 State changes are typographic or inversion, never glow
+- Button focus: `font-weight: 700; text-decoration: underline` — no ring, no glow.
+- Button active: **swap** foreground/background variables (`--mapped-primary` ↔
+  `--mapped-secondary`) — the terminal reverse-video effect.
+- Disabled: `text-decoration: line-through`.
+- Selection/highlight = an inverted block of color, like a TUI cursor bar.
+
+### 2.6 Half-line tricks and powerline caps
+Default buttons/`<pre>` paint their fill with a `linear-gradient` that leaves the top and
+bottom `0.5lh` transparent, so a 3-line-tall button reads as one text row with breathing
+room. Badges get powerline-style end caps with `clip-path`
+(`triangle`, `ribbon`, `slant-*`) — the same shapes as powerline glyphs `` ``.
+
+**Not adopted:** WebTUI's attribute-selector API (`is-="badge"`, `box-="square"` as
+authoring interface) and its `data-webtui-theme` switch. We keep cva variants, `cn()`,
+and our `data-theme` switch. We borrow the *CSS techniques*, not the framework.
+
+## 3. Design decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| D1 | Radius → 0 across the board | Terminals have no rounded cells. Single token flip. |
+| D2 | Kill all shadows and decorative gradients | WebTUI finding 2.3. Elevation = ladder step + border. |
+| D3 | Borders become solid ladder colors (no alpha) | Crisp 1px lines read as box-drawing; alpha borders read as "web". |
+| D4 | Map the shadcn palette onto an explicit bg0–3 / fg0–2 ladder | Keeps shadcn names; gives every surface/state a deterministic step. |
+| D5 | `--primary` per theme = the xterm cursor color | Chrome and embedded terminal share one accent: dark `#67d4b0` (teal), light `#1a7fc1` (blue), warm `#e58a5e` (already matches). Source: `src/features/terminals/logic/terminal-themes.ts`. |
+| D6 | Keep `focus-visible` rings (a11y) but restyle as a solid 1px offset outline; add reverse-video for `active`/selected | WebTUI drops focus rings entirely; we won't regress keyboard a11y in an Electron app. |
+| D7 | Animations become discrete: `steps()` timing or none | Terminals don't tween. Zoom/fade/slide on menus and dialogs is the single biggest "web app" tell. |
+| D8 | New-control sizing in `ch`/`lh`; existing px spacing tokens stay | Full grid retrofit of 4,205-line `shell.css` isn't worth it; new surfaces adopt the grid. |
+
+## 4. Token spec — `src/styles/tokens.css`
+
+### 4.1 Ladder mapping (shadcn names ⇄ WebTUI roles)
+
+| WebTUI role | shadcn token | Used for |
+|---|---|---|
+| `background0` | `--background` | App/window base |
+| `background1` | `--card`, `--popover` | Panes, menus, dialogs |
+| `background2` | `--muted`, `--secondary`, `--accent` | Hover step, inactive fills, input fill |
+| `background3` | `--border`, `--input` | All borders (solid, no alpha) |
+| `foreground0` | `--foreground`, `--card-foreground`, … | Primary text |
+| `foreground2` | `--muted-foreground` | Secondary text, placeholders |
+| cursor accent | `--primary`, `--ring`, `--accent` (interactive) | Selection bar, focus, links |
+
+### 4.2 Dark theme (`:root`) — before → after
+
+```css
+:root {
+	--radius: 0rem;                                  /* was 0.625rem */
+
+	/* ladder: near-neutral charcoal, slight blue cast to match xterm bg #06090d */
+	--background: oklch(0.16 0.015 240);             /* bg0 — was 0.129 0.042 264 (slate-blue) */
+	--foreground: oklch(0.96 0.01 200);              /* fg0 */
+	--card: oklch(0.20 0.015 240);                   /* bg1 — pane surface */
+	--card-foreground: var(--foreground);
+	--popover: oklch(0.20 0.015 240);                /* bg1 — flat, not "elevated" */
+	--popover-foreground: var(--foreground);
+	--muted: oklch(0.26 0.015 240);                  /* bg2 — hover/inactive step */
+	--muted-foreground: oklch(0.68 0.02 230);        /* fg2 */
+	--secondary: oklch(0.26 0.015 240);              /* bg2 */
+	--secondary-foreground: var(--foreground);
+	--accent: oklch(0.26 0.015 240);                 /* bg2 — menu-item hover stays a ladder step */
+	--accent-foreground: var(--foreground);
+	--primary: oklch(0.78 0.13 175);                 /* ≈ #67d4b0 — xterm dark cursor teal */
+	--primary-foreground: oklch(0.16 0.015 240);     /* reverse-video pair */
+	--destructive: oklch(0.704 0.191 22.216);        /* keep */
+	--border: oklch(0.34 0.015 240);                 /* bg3 — was oklch(1 0 0 / 10%) ← no more alpha */
+	--input: oklch(0.26 0.015 240);                  /* input FILL (bg2), not border alpha */
+	--ring: var(--primary);                          /* focus = accent, was gray-blue */
+}
+```
+
+### 4.3 Light theme (`[data-theme="light"]`)
+Same ladder, inverted: `--background: oklch(0.985 0.005 240)` (paper, not pure white —
+pure `#fff` + 1px dark borders moirés), `--card: oklch(0.955 …)`, `--muted: oklch(0.92 …)`,
+`--border: oklch(0.80 …)`, `--primary: oklch(0.55 0.13 240)` (≈ `#1a7fc1` xterm light
+cursor), `--ring: var(--primary)`.
+
+### 4.4 Warm theme
+Already 90% there (terracotta primary = warm xterm cursor). Only changes:
+`--border: #4a3f31` stays (already solid ✓); set `--popover: var(--card)` (drop the
+elevated `#342c22` step — D2); `--ring: var(--primary)` (was `#6d5b46`).
+
+### 4.5 Radius guard (required, not optional)
+With `--radius: 0rem`, the derived tokens go negative:
+`--radius-sm: calc(var(--radius) - 4px)` → `-4px`, which is *invalid* `border-radius` and
+falls back unpredictably. Clamp them in the `@theme inline` block:
+
+```css
+--radius-sm: max(0px, calc(var(--radius) - 4px));
+--radius-md: max(0px, calc(var(--radius) - 2px));
+--radius-lg: var(--radius);
+--radius-xl: max(0px, calc(var(--radius) + 4px));
+```
+(Also fix the legacy-bridge copies at `tokens.css:42-44`.) This keeps `rounded-md`
+classes in `ui/*.tsx` valid — they all collapse to square — and preserves the option to
+ship a "soft-TUI" mode later by flipping `--radius` back to `0.25rem`.
+
+### 4.6 Grid + font tokens (new)
+```css
+:root {
+	line-height: 1.4;            /* pin it so 1lh is deterministic everywhere */
+	--cell-w: 1ch;
+	--cell-h: 1lh;
+	--box-border-width: 1px;
+}
+```
+`--font-ui` is already monospace (SF Mono stack in `shell.css`) — the hardest TUI
+prerequisite is already met. Move `--font-ui`/`--font-terminal` declarations from
+`shell.css:1-30` into `tokens.css` so the token file is the single theming surface, and
+register them as `--font-mono` in `@theme inline` for Tailwind's `font-mono` utility.
+
+## 5. Component spec — `src/components/ui/*.tsx`
+
+Class-string edits only; no structural/API changes. Variants keep their names so call
+sites don't change.
+
+### 5.1 `button.tsx`
+Base string, before:
+```
+… rounded-md text-sm font-medium transition-colors focus-visible:ring-1 focus-visible:ring-ring …
+```
+After:
+```
+… rounded-none text-sm font-medium transition-none
+focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-1 focus-visible:outline-ring
+active:bg-foreground active:text-background
+disabled:pointer-events-none disabled:opacity-50 …
+```
+Per-variant: strip every `shadow`/`shadow-sm`; replace alpha hovers with ladder steps —
+`default`: `hover:bg-primary/90` → keep `bg-primary text-primary-foreground`, hover via
+brightness step is fine to keep as `/90` *only if* D2-strictness loses; preferred:
+`hover:underline`. `outline`: `border border-border bg-transparent hover:bg-muted`.
+`ghost`: `hover:bg-muted`. Sizes `sm`/`lg`: drop the redundant `rounded-md`.
+
+Optional WebTUI flourish (behind a new `variant: "reverse"` if wanted): focused/primary
+buttons render reverse-video (`bg-foreground text-background`) — the strongest TUI cue.
+
+### 5.2 `input.tsx` / `textarea.tsx`
+WebTUI inputs are **filled, borderless** (`background: var(--background1)`, placeholder
+`--foreground2`, no focus ring — the block cursor is the affordance). Adapted:
+`border border-input bg-transparent shadow-sm` → `border-0 bg-input rounded-none`,
+keep `focus-visible:outline-1 outline-ring`, `placeholder:text-muted-foreground`
+(now fg2). Drop `transition-colors`.
+
+### 5.3 `dialog.tsx`
+- `DialogContent`: `rounded-lg border shadow-lg` → `rounded-none border border-border`;
+  delete all `data-[state=…]:zoom-*` / `slide-*` / `fade-*` animation classes (D7) —
+  dialogs appear instantly; `sm:max-w-lg` → `max-w-[64ch]` (WebTUI default dialog width).
+- `DialogOverlay`: keep `bg-black/80`, delete fade animations. No backdrop blur ever.
+
+### 5.4 `tabs.tsx`
+The pill pattern (`TabsList: bg-muted rounded-lg p-1`, trigger `rounded-md shadow`) is
+the most "web" component in the set. TUI tabs are a text row on a border line:
+- `TabsList`: `rounded-none bg-transparent p-0 gap-[1ch] border-b border-border h-auto`.
+- `TabsTrigger`: `rounded-none px-[1ch] data-[state=active]:bg-foreground
+  data-[state=active]:text-background` (reverse-video active tab — finding 2.5), or the
+  quieter `data-[state=active]:border-b-2 data-[state=active]:border-primary`.
+  Recommend reverse-video; it's the signature move.
+
+### 5.5 `dropdown-menu.tsx` / `context-menu.tsx`
+- Content: `rounded-md shadow-md` → `rounded-none border-border` (no shadow — a 1px
+  solid border against bg0 is exactly how TUI popovers separate).
+- Delete `data-[state]` zoom/slide/fade animation classes (D7).
+- Items: `rounded-sm focus:bg-accent` → `rounded-none focus:bg-primary
+  focus:text-primary-foreground` — the highlighted row is an accent selection bar, the
+  single most recognizable TUI interaction.
+- Padding: `px-2 py-1.5` → `px-[1ch] py-0 min-h-[1lh]` where it doesn't break icon rows.
+
+### 5.6 `switch.tsx`
+`rounded-full` track/thumb → `rounded-none`; thumb `shadow-lg` → none; checked track
+`bg-primary`. Result reads as a `[■ ]`/`[ ■]` toggle cell. Keep the translate animation
+but add `transition-none` (it snaps — D7).
+
+### 5.7 `scroll-area.tsx`
+Thumb `rounded-full bg-border` → `rounded-none bg-border hover:bg-muted-foreground`;
+keep 2.5 width. Square thumb on square track = terminal scrollbar.
+
+## 6. Shell spec — `src/app/shell.css`
+
+1. **Background gradients** (lines ~42–75): delete the three
+   `radial-gradient(circle at top, …)` washes → flat `var(--background)` (D2).
+2. **Glow shadows**: `box-shadow: 0 0 16px color-mix(…)` action/attention glows →
+   solid border-color change, optionally blinking:
+   ```css
+   @keyframes tui-blink { 50% { border-color: transparent; } }
+   animation: tui-blink 1s steps(1) infinite;   /* steps(), never ease */
+   ```
+3. **Attention spotlight** (lines ~648–748): the rotating conic-gradient ring is the
+   opposite of TUI motion. Replace with the blink above, or a `steps(4)` ASCII-spinner
+   (`◐◓◑◒` / `⠋⠙⠸⠴` as `::before` content cycling via keyframed `content`).
+4. **Pane borders → titled boxes**: the four `--pane-border-*` rgba colors become
+   full-opacity theme tokens, and panes adopt the WebTUI box+shear technique so each pane
+   title sits *on* its border line (`┌─ SESSIONS ───┐`). See §7 utility.
+5. **Inset/hover rgba overlays**: replace `rgba(...)` hovers with `var(--muted)` steps.
+
+## 7. New file: `src/styles/tui.css` — grid utilities
+
+A small `@layer utilities` file imported after `tokens.css`, porting the two WebTUI
+drawing techniques worth owning:
+
+```css
+@layer utilities {
+	/* WebTUI box technique, adapted: border drawn at half-cell inset */
+	.tui-box {
+		position: relative;
+		isolation: isolate;
+		padding: 1lh 1ch;
+	}
+	.tui-box::before {
+		content: "";
+		position: absolute;
+		top: 50%; left: 50%;
+		translate: -50% -50%;
+		width: calc(100% - 1ch - var(--box-border-width));
+		height: calc(100% - 1lh - var(--box-border-width));
+		border: var(--box-border-width) solid var(--box-border-color, var(--border));
+		z-index: -1;
+	}
+	/* collapse top padding so a title row overlaps the border line */
+	.tui-box-shear-top { padding-top: 0; }
+	.tui-box > .tui-box-title {
+		display: inline-block;
+		background: var(--card);       /* punches a gap in the border line */
+		padding-inline: 1ch;
+		color: var(--muted-foreground);
+	}
+}
+```
+Accent variants via `style={{ "--box-border-color": "var(--pane-border-terminal)" }}` —
+this replaces today's plain `border` + absolutely-positioned pane title labels.
+
+Optional second utility: powerline badge caps for the provider chips
+(`--provider-claude`/`--provider-codex`). The bundled Meslo Powerline font already has
+the glyphs — `::before { content: ""; }` / `::after { content: ""; }` beats
+WebTUI's clip-path version since we ship the font anyway.
+
+## 8. Migration phases
+
+| Phase | Scope | Files | Risk |
+|---|---|---|---|
+| 1 | Tokens: radius 0 + clamp, ladder colors, solid borders, ring=primary, font tokens move | `tokens.css` | Low — whole app shifts at once, but reversible by git revert; visually noisy diff to review by screenshot |
+| 2 | Primitives: shadow/animation/radius strip, reverse-video states, selection bars | `src/components/ui/*.tsx` (9 files) | Low — class strings only |
+| 3 | Chrome: gradients, glows, blink/steps animations, rgba→token sweep | `shell.css`, `UpdateBanner.css` | Medium — 4,205 lines, do it as grep-driven passes (`radial-gradient`, `box-shadow`, `rgba(`) |
+| 4 | Flourish: `tui.css` titled pane boxes, powerline caps, `marker-tree` for `WorktreeTree` | new `tui.css`, pane components | Medium — layout-affecting (padding becomes 1lh/1ch) |
+
+Each phase is independently shippable; stop after phase 2 and the app already reads as a
+TUI (flat, square, monospace, reverse-video selection).
+
+## 9. Acceptance criteria
+
+> **Scope note (dark launch):** these were written for the in-place restyle of §8.
+> Under the §10 delivery plan they split into two groups: criteria that hold *within
+> the `tui` theme* now, and grep-based criteria that can only go to zero at flatten
+> (PR G), because until then the base classes deliberately keep their stock
+> shadows/radii/alpha borders for the other themes.
+
+Holds now, within `data-theme="tui"`:
+
+- [x] Every primitive shadow is neutralized via `tui:shadow-none`; remaining shell
+  `box-shadow`s are zeroed per-selector in `tui.css` (ring-`box-shadow` focus
+  indicators intentionally kept — D6).
+- [x] No `border-radius` > 0 renders (`--radius: 0rem` + §4.5 clamps; verified via
+  gallery screenshots `tests/__screenshots__/ui-gallery-tui*.png`).
+- [x] No alpha-channel borders in the `[data-theme="tui"]` token block; pane accent
+  borders are solid hex in `tui.css`.
+- [x] Dropdown/context-menu/dialog open with no motion (animation durations zeroed —
+  §12); highlighted item is a solid `--primary` accent bar.
+- [x] App chrome accent matches the xterm dark cursor teal (D5).
+- [ ] Keyboard focus visible on every interactive primitive — tab-through pass still
+  owed before sign-off (D6; gallery covers focus-visible states statically).
+- [ ] Monaco + xterm panes visually continuous with chrome — needs an in-app pass
+  (gallery doesn't embed Monaco/xterm).
+
+Deferred to flatten (PR G):
+
+- [ ] `grep -c "shadow" src/components/ui/*.tsx` → 0 (excluding `shadow-none`).
+- [ ] `grep "oklch(1 0 0 /" src/styles/tokens.css` → 0 (the `:root` dark block still
+  carries the stock alpha borders until TUI becomes the dark default).
+- [ ] No `border-radius` > 0 in dark/light/warm (only relevant if G restyles them).
+- [ ] Light theme contrast ≥ 4.5:1 (no TUI light ladder was built — see §12).
+
+## 10. Delivery plan: TUI as an opt-in theme (dark launch)
+
+The restyle ships as a **fourth theme** (`data-theme="tui"`) so it is reviewable in
+isolation, iterable behind a toggle, and invisible to parallel feature work until
+explicitly promoted. This supersedes the in-place phases in §8 as the merge strategy
+(§8's ordering still applies *within* the theme).
+
+### 10.1 Isolation mechanics
+
+- **Tokens**: all §4 values go in a `[data-theme="tui"]` block in `tokens.css`.
+  `:root`, light, and warm remain byte-identical.
+- **Primitives**: instead of rewriting cva strings, add a Tailwind custom variant next
+  to the existing `dark` one:
+  ```css
+  @custom-variant tui (&:is([data-theme="tui"] *));
+  ```
+  Component edits become additive (`tui:shadow-none tui:rounded-none tui:transition-none
+  tui:focus-visible:ring-0 …`). Existing themes render unchanged; conflicts with
+  concurrent feature branches are append-only.
+- **Shell chrome**: §6 overrides live in `tui.css`, every rule scoped under
+  `[data-theme="tui"]` — `shell.css` itself is not edited until flatten.
+- **Theme plumbing**: add `"tui"` to `src/lib/use-theme.ts` (maps to Monaco/xterm
+  `dark` until a dedicated xterm palette lands).
+
+### 10.2 Review tooling (build first)
+
+- **Gallery route** (dev-only): renders all 9 primitives in every state — default,
+  hover, focus-visible, disabled, open menus/dialog — plus a mock titled-pane layout.
+- **Playwright screenshot script**: captures the gallery per theme into
+  `tests/__screenshots__/`; PRs attach before/after PNGs. Review = compare two images,
+  not read CSS diffs.
+
+### 10.3 PR sequence (each independently revertable, zero visual change until G)
+
+| PR | Content | Status |
+|---|---|---|
+| A | Scaffold: `tui` theme option, `@custom-variant tui`, empty `tui.css`, gallery page, screenshot script | ✅ `9211ebc` |
+| B | `[data-theme="tui"]` token block (§4: ladder, radius 0 + clamp, solid borders, ring=primary) | ✅ `0f2d49f` |
+| C | Buttons + input + textarea (`tui:` classes, §5.1–5.2) | ✅ `2684f7c` |
+| D | Dialog + dropdown-menu + context-menu (§5.3, §5.5) | ✅ `af3e364` |
+| E | Tabs + switch + scroll-area (§5.4, §5.6–5.7) | ✅ `08a345b` |
+| F | Shell chrome in `tui.css`: gradients, glows, titled pane boxes (§6–§7) | ✅ `b2ed2b8` |
+| G | **Flatten** (after sign-off): TUI tokens become the dark default, `tui:` prefixes inlined into base classes, theme scaffolding + `tw-animate-css` removed | ⬜ gated on sign-off |
+
+Until G, the TUI look is toggleable in-app for side-by-side comparison with the current
+design, and a disliked direction is a one-PR revert. G is the only PR that changes what
+users see by default, and by then every visual has been individually approved.
+
+## 11. Risks / open questions
+
+- **`lh` units in Electron/Chromium ≥ 120**: supported, but `1lh` inside flex children
+  resolves against the element's own line-height — pin `line-height` at `:root` (§4.6)
+  and avoid overriding it on containers that use `lh` sizing.
+- **Reverse-video active states** (buttons/tabs) are bold; if too aggressive after a
+  screenshot pass, fall back to accent-bar styles — both specced above.
+- **Warm theme identity**: radius 0 + no glow changes its cozy feel the most. Consider
+  `[data-theme="warm"] { --radius: 0.25rem; }` as a deliberate per-theme override —
+  the token architecture supports it for free.
+- **`tw-animate-css` import** becomes mostly dead after phase 2; drop it in phase 3 to
+  trim the bundle.
+
+## 12. As-built implementation notes (PRs A–F)
+
+Where the implementation deviates from the sections above, the code is the spec.
+
+### 12.1 Deviations
+
+- **`tui.css` is deliberately *unlayered*, not `@layer utilities` (§7).** Unlayered CSS
+  beats all `@layer` rules in the cascade, so the theme overrides win over both
+  Tailwind utilities and `shell.css` without specificity games. The file is deleted at
+  flatten either way.
+- **Motion kill is duration-zeroing, not class deletion (§5.3, §5.5, D7).** Instead of
+  removing `data-[state]` zoom/slide/fade classes (which would change all themes),
+  `tui.css` sets `animation-duration: 0s` on `[data-state="open"|"closed"]` elements.
+  This keeps Radix's animation-end unmount logic working and stays additive. A
+  consequence: `tw-animate-css` is still imported and live for the other themes — its
+  removal moves wholly into PR G.
+- **Shadow removal is per-selector, not blanket.** A blanket `box-shadow: none` would
+  also kill Tailwind `ring-*` focus indicators (they're box-shadows), regressing D6.
+  `tui.css` zeroes an explicit list of shell chrome selectors; crisp `0 0 0 1px`
+  border-shadows and the active-tab inset underline are kept as discrete lines.
+- **`.tui-box-title` is absolutely positioned on the border line** (`top: 0; left: 2ch`)
+  instead of the WebTUI shear/padding-collapse technique (§2.4, §7) — same visual,
+  simpler interaction with flex children. There is no `.tui-box-shear-top` class.
+- **Pane accent borders are solid hex** (`#4fb3ff`, `#f6a94a`, `#43d39e`, `#f36b8a`)
+  redefining the `--pane-border-*` custom properties under `[data-theme="tui"]`,
+  rather than a `shell.css` rgba→token sweep (deferred to G).
+- **Attention states**: the rotating conic spotlight and breathing glows are replaced
+  by `tui-attention-blink` (`steps(1)` opacity blink, 1.2s activity / 0.7s
+  action-required) rather than the border-color blink sketched in §6.2, with an
+  explicit `prefers-reduced-motion` freeze (tui.css loads after shell.css and would
+  otherwise override its reduced-motion block).
+- **Gallery is hash-gated, not a route**: `#/ui-gallery` in `src/main.tsx` swaps the
+  app root for `src/app/UiGallery.tsx`; screenshots come from
+  `tests/e2e/ui-gallery.screenshots.spec.ts` into `tests/__screenshots__/`
+  (4 captures — base, dropdown, context, dialog — per theme × dark/light/warm/tui).
+- **Grid tokens live only in the `tui` block**: `line-height: 1.4`, `--cell-w/h`,
+  `--box-border-width` are set under `[data-theme="tui"]`, not `:root` (§4.6 said
+  `:root`; scoping keeps other themes byte-identical until G).
+
+### 12.2 Specced but not built (candidates for G or post-G)
+
+- **Light/warm TUI ladders (§4.3–4.4)**: only the dark TUI palette exists. The light
+  paper ladder and warm adjustments apply only if G restyles those themes too.
+- **Pane adoption of `.tui-box` (§6.4)**: the utility ships and is exercised in the
+  gallery's mock titled-pane layout, but real shell panes still use plain borders +
+  positioned title labels. Layout-affecting (`1lh/1ch` padding) — deferred.
+- **Powerline badge caps (§7, optional)**: not implemented.
+- **`marker-tree` for `WorktreeTree` (§8 phase 4)**: not implemented.
+- **Dedicated xterm TUI palette**: `use-theme.ts` maps `tui` → Monaco/xterm `dark` as
+  planned (§10.1); a matched xterm theme remains open.
+
+### 12.3 Risk outcomes (§11)
+
+- `lh` units: pinned `line-height: 1.4` in the `tui` token block; no flex-child
+  resolution issues observed in the gallery captures.
+- Reverse-video active states: shipped on buttons (`active:`) and tabs
+  (`data-[state=active]`); kept after screenshot review.
+- Warm theme identity: untouched — dark launch made the per-theme radius question moot
+  until G.
+- `tw-animate-css`: still imported (see §12.1 motion note); drop in G.

--- a/tests/e2e/ui-gallery.screenshots.spec.ts
+++ b/tests/e2e/ui-gallery.screenshots.spec.ts
@@ -1,0 +1,106 @@
+import {
+	_electron as electron,
+	expect,
+	test,
+	type ElectronApplication,
+	type Page,
+} from "@playwright/test";
+import { mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { mkdtempSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { createTestRepo, type TestRepo } from "./fixtures/create-test-repo";
+import { closeApp } from "./fixtures/close-app";
+
+/**
+ * Captures the #/ui-gallery primitive gallery per theme into
+ * tests/__screenshots__/ for visual review of theme PRs
+ * (docs/tui-css-spec.md §10.2). Not an assertion suite — it exists to
+ * produce before/after PNGs, so keep it filterable:
+ *
+ *   pnpm build && pnpm exec playwright test ui-gallery
+ */
+const PALETTES = ["dark", "light", "warm", "tui"] as const;
+const OUT_DIR = join(
+	dirname(fileURLToPath(import.meta.url)),
+	"..",
+	"__screenshots__",
+);
+
+let app: ElectronApplication;
+let page: Page;
+let testRepo: TestRepo;
+
+test.beforeAll(async () => {
+	mkdirSync(OUT_DIR, { recursive: true });
+	testRepo = createTestRepo();
+	const persistedStateDir = realpathSync(
+		mkdtempSync(join(tmpdir(), "ofa-gallery-")),
+	);
+	app = await electron.launch({
+		args: ["out/main/index.js"],
+		env: {
+			...process.env,
+			AI14ALL_E2E: "1",
+			AI14ALL_E2E_PICK_PATH: testRepo.repoPath,
+			AI14ALL_WORKSPACE_STATE_PATH: join(
+				persistedStateDir,
+				"workspace-state.json",
+			),
+		},
+	});
+	page = await app.firstWindow({ timeout: 60_000 });
+	// The gallery gate in main.tsx only checks the hash at load, so set it
+	// and reload (safe in a production build — no HMR guard).
+	await page.evaluate(() => {
+		window.location.hash = "#/ui-gallery";
+		window.location.reload();
+	});
+	await expect(page.getByTestId("ui-gallery")).toBeVisible({
+		timeout: 30_000,
+	});
+});
+
+test.afterAll(async () => {
+	await closeApp(app);
+	testRepo?.cleanup();
+});
+
+for (const palette of PALETTES) {
+	test(`capture ${palette} gallery`, async () => {
+		await page.getByTestId(`gallery-theme-${palette}`).click();
+		await expect(page.locator("html")).toHaveAttribute("data-theme", palette);
+		// Let theme-driven repaints (fonts, scrollbars) settle.
+		await page.waitForTimeout(200);
+
+		await page.screenshot({
+			path: join(OUT_DIR, `ui-gallery-${palette}.png`),
+			fullPage: true,
+		});
+
+		await page.getByTestId("gallery-open-dialog").click();
+		await expect(page.getByTestId("gallery-dialog-content")).toBeVisible();
+		await page.screenshot({
+			path: join(OUT_DIR, `ui-gallery-${palette}-dialog.png`),
+		});
+		await page.keyboard.press("Escape");
+		await expect(page.getByTestId("gallery-dialog-content")).toHaveCount(0);
+
+		await page.getByTestId("gallery-open-dropdown").click();
+		await expect(page.getByTestId("gallery-dropdown-content")).toBeVisible();
+		await page.screenshot({
+			path: join(OUT_DIR, `ui-gallery-${palette}-dropdown.png`),
+		});
+		await page.keyboard.press("Escape");
+		await expect(page.getByTestId("gallery-dropdown-content")).toHaveCount(0);
+
+		await page.getByTestId("gallery-context-target").click({ button: "right" });
+		await expect(page.getByTestId("gallery-context-content")).toBeVisible();
+		await page.screenshot({
+			path: join(OUT_DIR, `ui-gallery-${palette}-context.png`),
+		});
+		await page.keyboard.press("Escape");
+		await expect(page.getByTestId("gallery-context-content")).toHaveCount(0);
+	});
+}


### PR DESCRIPTION
## Summary

Preserves three spec artifacts on a dedicated branch ahead of feature-branch cleanup:

- **Onboarding flow design spec** (2026-06-10), superseding the 2026-05-31 wizard spec — cherry-picked from `feat/terminal-ui-theme` (826c7cc).
- **Terminal UI theme CSS spec**, as-built through PR F: includes status updates, split sign-off criteria, and §12 as-built deviations that previously existed only as uncommitted edits.
- **UI gallery screenshot smoke spec** (`tests/e2e/ui-gallery.screenshots.spec.ts`) with the ESM `import.meta.url` output-dir fix (399d141).

## Notes

- The smoke spec drives the `#/ui-gallery` route, which ships with TUI phase A and is not on `devel` yet — it is preserved here as an artifact and goes green once the TUI work lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)