### PR TITLE
fix: devel smoke-test UI fixes (cursor, note drawer, dirty bar, double close)

### DIFF
--- a/docs/superpowers/specs/2026-06-10-devel-smoke-test-ui-fixes-design.md
+++ b/docs/superpowers/specs/2026-06-10-devel-smoke-test-ui-fixes-design.md
@@ -1,0 +1,74 @@
+# Devel smoke-test UI fixes: cursor, note drawer, dirty bar, double close
+
+Date: 2026-06-10
+Status: Approved — implementing
+Branch: `smoke-test-fixes-2` (off `devel`)
+
+## Problem
+
+A manual smoke pass on `devel` (post PR #15) surfaced five UI regressions. Four
+were already fixed on `fix/smoke-test-ui-fixes`, but that branch was never
+merged into `devel` and is slated for deletion, so the fixes must be carried
+over. The fifth needs a new (one-line) change.
+
+1. **Buttons without pointer cursor.** Tailwind v4 preflight sets
+   `cursor: default` on `button`; `src/styles/tokens.css` on `devel` has no
+   restoring rule, so enabled buttons read as inert.
+2. **Notes chrome renders as a centered dialog.** shadcn `DialogContent`'s
+   `left-[50%]` utility wins over `.shell-note-sheet`'s `right: 0`
+   (`src/app/shell.css:1864`) — when both `left` and `right` are set with an
+   explicit width, `left` wins in LTR. The session-note drawer therefore
+   appears centered instead of docked.
+3. **Save/Discard buttons in the file edit view have no button layout.**
+   `EditorDirtyBar.tsx` still references `.shell-btn` / `.shell-btn--primary`,
+   but that CSS was purged from `shell.css` during the shadcn migration
+   (0 matches on `devel`), leaving bare unstyled text buttons.
+4. **Double X (close) in the notes dialog.** `src/components/ui/dialog.tsx`
+   renders its built-in `DialogPrimitive.Close` unconditionally; `NoteSheet`
+   renders its own header close button, so two X buttons appear.
+5. **Note drawer appear animation.** `DialogContent`'s default
+   `data-[state=open]` zoom/fade animation is center-anchored and unwanted for
+   an edge-docked drawer. Desired behavior: docked to the right edge, appears
+   instantly, no animation.
+
+Issues 2 and 5 (position) share one root cause; issue 5's animation half needs
+the new change.
+
+## Fix
+
+Cherry-pick the four existing fix commits from `fix/smoke-test-ui-fixes` onto
+`smoke-test-fixes-2`, in order, then add one new commit:
+
+| # | Commit | Change |
+|---|--------|--------|
+| 1 | `5c29804` | `tokens.css`: restore `cursor: pointer` on enabled buttons (7 lines). |
+| 2 | `216023e` | `shell.css`: `left: auto;` on `.shell-note-sheet` so the drawer re-docks right. |
+| 3 | `5e76bef` | `EditorDirtyBar.tsx`: migrate Save/Discard to shadcn `Button` (default + secondary variants). |
+| 4 | `b18b802` | `dialog.tsx`: add `showCloseButton` prop (default `true`); opt out `NoteSheet`, `MarkdownPreviewModal`, `ShortcutsHelp`; update their unit tests. |
+| 5 | new | `shell.css`: `animation: none;` in the `.shell-note-sheet` rule, killing the center-anchored open animation. |
+
+Explicitly **not** cherry-picked: `7cf05be` (`bea1850` on
+`fix/smoke-test-ui-fixes`), the 400ms slide-in for the note drawer — the
+decided behavior is no appear animation at all. Commit 5 is that commit's
+`animation: none;` hunk without the keyframes.
+
+## Out of scope
+
+- Restyling other dialogs' animations (shortcuts help, markdown preview,
+  files overlay keep stock behavior).
+- The TUI theme work (`feat/terminal-ui-theme`); `docs/tui-css-spec.md` covers
+  it separately.
+
+## Verification
+
+1. Unit: `pnpm test` — must pass, specifically
+   `tests/unit/components/NoteSheet.test.tsx` (gains a no-built-in-close
+   assertion via commit 4) and `tests/unit/components/MarkdownPreviewModal.test.tsx`.
+2. Build: `pnpm exec electron-vite build` — clean.
+3. Manual smoke, one check per issue:
+   - hover any enabled button → pointer cursor; disabled → default;
+   - open session notes → drawer docked flush to the right edge;
+   - drawer appears instantly, no zoom/fade/slide;
+   - exactly one X in the notes drawer header;
+   - edit a file → Save (primary) and Discard (secondary) render as buttons.
+4. Push `smoke-test-fixes-2` to origin.

--- a/docs/superpowers/specs/2026-06-10-devel-smoke-test-ui-fixes-design.md
+++ b/docs/superpowers/specs/2026-06-10-devel-smoke-test-ui-fixes-design.md
@@ -44,7 +44,7 @@ Cherry-pick the four existing fix commits from `fix/smoke-test-ui-fixes` onto
 | 1 | `5c29804` | `tokens.css`: restore `cursor: pointer` on enabled buttons (7 lines). |
 | 2 | `216023e` | `shell.css`: `left: auto;` on `.shell-note-sheet` so the drawer re-docks right. |
 | 3 | `5e76bef` | `EditorDirtyBar.tsx`: migrate Save/Discard to shadcn `Button` (default + secondary variants). |
-| 4 | `b18b802` | `dialog.tsx`: add `showCloseButton` prop (default `true`); opt out `NoteSheet`, `MarkdownPreviewModal`, `ShortcutsHelp`; update their unit tests. |
+| 4 | `b18b802` | `dialog.tsx`: add `hideClose` prop (default `false`, built-in close shown); opt out `NoteSheet`, `MarkdownPreviewModal`, `ShortcutsHelp`; update their unit tests. |
 | 5 | new | `shell.css`: `animation: none;` in the `.shell-note-sheet` rule, killing the center-anchored open animation. |
 
 Explicitly **not** cherry-picked: `7cf05be` (`bea1850` on

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -1866,6 +1866,7 @@ select {
 	top: 0;
 	right: 0;
 	bottom: 0;
+	left: auto; /* beat shadcn DialogContent's left-[50%] utility */
 	width: calc(clamp(280px, 28vw, 420px) + 140px);
 	background: var(--panel-bg);
 	border-left: 1px solid var(--panel-border);

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -1876,6 +1876,9 @@ select {
 	padding: var(--space-4);
 	z-index: 50;
 	outline: none;
+	/* drawer appears instantly: suppress shadcn DialogContent's
+	   center-anchored zoom/fade open animation */
+	animation: none;
 }
 
 .shell-note-sheet__header {

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -31,8 +31,10 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 const DialogContent = React.forwardRef<
 	React.ElementRef<typeof DialogPrimitive.Content>,
-	React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+	React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+		hideClose?: boolean;
+	}
+>(({ className, children, hideClose = false, ...props }, ref) => (
 	<DialogPortal>
 		<DialogOverlay />
 		<DialogPrimitive.Content
@@ -44,10 +46,12 @@ const DialogContent = React.forwardRef<
 			{...props}
 		>
 			{children}
-			<DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-				<X className="h-4 w-4" />
-				<span className="sr-only">Close</span>
-			</DialogPrimitive.Close>
+			{!hideClose && (
+				<DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+					<X className="h-4 w-4" />
+					<span className="sr-only">Close</span>
+				</DialogPrimitive.Close>
+			)}
 		</DialogPrimitive.Content>
 	</DialogPortal>
 ));

--- a/src/features/shortcuts/ShortcutsHelp.tsx
+++ b/src/features/shortcuts/ShortcutsHelp.tsx
@@ -76,6 +76,7 @@ export function ShortcutsHelp({ open, platform, onClose }: Props) {
 			<DialogContent
 				className="shell-shortcuts-help"
 				data-testid="shortcuts-help"
+				hideClose
 			>
 				<div className="shell-shortcuts-help__header">
 					<DialogTitle className="shell-shortcuts-help__title">

--- a/src/features/viewer/components/EditorDirtyBar.tsx
+++ b/src/features/viewer/components/EditorDirtyBar.tsx
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { Button } from "@/components/ui/button";
 
 export type EditorDirtyBarProps = {
 	currentLength: number;
@@ -41,16 +42,17 @@ export function EditorDirtyBar({
 			<span className="shell-editor-dirty-bar__hint">
 				<kbd>⌘S</kbd>
 			</span>
-			<button
-				type="button"
-				className="shell-btn shell-btn--primary"
-				onClick={onSave}
-			>
+			<Button type="button" variant="default" size="sm" onClick={onSave}>
 				Save
-			</button>
-			<button type="button" className="shell-btn" onClick={handleDiscard}>
+			</Button>
+			<Button
+				type="button"
+				variant="secondary"
+				size="sm"
+				onClick={handleDiscard}
+			>
 				Discard
-			</button>
+			</Button>
 		</div>
 	);
 }

--- a/src/features/viewer/components/MarkdownPreviewModal.tsx
+++ b/src/features/viewer/components/MarkdownPreviewModal.tsx
@@ -80,7 +80,7 @@ export function MarkdownPreviewModal({
 				if (!isOpen) onClose();
 			}}
 		>
-			<DialogContent className="shell-md-modal" aria-describedby={undefined}>
+			<DialogContent className="shell-md-modal" aria-describedby={undefined} hideClose>
 				<div className="shell-md-modal__header">
 					<DialogTitle className="shell-md-modal__title">
 						{relativePath}

--- a/src/features/workspace/components/NoteSheet.tsx
+++ b/src/features/workspace/components/NoteSheet.tsx
@@ -27,7 +27,7 @@ export function NoteSheet({ open, note, onNoteChange, onClose }: Props) {
 				if (!v) onClose();
 			}}
 		>
-			<DialogContent className="shell-note-sheet" aria-describedby={undefined}>
+			<DialogContent className="shell-note-sheet" aria-describedby={undefined} hideClose>
 				<div className="shell-note-sheet__header">
 					<DialogTitle className="shell-note-sheet__title">
 						Session note

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -127,4 +127,11 @@
 	* {
 		border-color: var(--border);
 	}
+
+	/* Tailwind v4 preflight sets cursor: default on buttons; this app's
+	   buttons are all clickable controls, so restore the v3 behavior. */
+	button:not(:disabled),
+	[role="button"]:not(:disabled) {
+		cursor: pointer;
+	}
 }

--- a/tests/unit/components/MarkdownPreviewModal.test.tsx
+++ b/tests/unit/components/MarkdownPreviewModal.test.tsx
@@ -214,14 +214,7 @@ describe("MarkdownPreviewModal", () => {
 		);
 
 		await screen.findByRole("heading", { name: "Hello" });
-		// The shadcn DialogContent renders its own built-in close button in
-		// addition to the modal's custom "shell-md-modal__close" button, so both
-		// share the accessible name "Close". Target the custom one explicitly.
-		const closeButtons = screen.getAllByRole("button", { name: "Close" });
-		const customClose = closeButtons.find((el) =>
-			el.classList.contains("shell-md-modal__close"),
-		);
-		fireEvent.click(customClose ?? closeButtons[0]);
+		fireEvent.click(screen.getByRole("button", { name: "Close" }));
 		expect(onClose).toHaveBeenCalled();
 	});
 });

--- a/tests/unit/components/NoteSheet.test.tsx
+++ b/tests/unit/components/NoteSheet.test.tsx
@@ -84,4 +84,9 @@ describe("NoteSheet", () => {
 			"## Finding\n\n- First item",
 		);
 	});
+
+	it("renders exactly one close button", () => {
+		render(<NoteSheet open note="" onNoteChange={() => {}} onClose={() => {}} />);
+		expect(screen.getAllByRole("button", { name: /close/i })).toHaveLength(1);
+	});
 });


### PR DESCRIPTION
## Summary

Fixes the five UI regressions found in the post-PR-#15 smoke pass on `devel`, per the included spec (`docs/superpowers/specs/2026-06-10-devel-smoke-test-ui-fixes-design.md`):

- **Pointer cursor restored** on enabled buttons (Tailwind v4 preflight regression) — cherry-pick of `5c29804`.
- **Session note drawer re-docked** to the right edge (`left: auto` beats shadcn `DialogContent`'s `left-[50%]`) — cherry-pick of `216023e`.
- **Save/Discard in the file edit view** migrated from the purged `.shell-btn` classes to shadcn `Button` — cherry-pick of `5e76bef`.
- **Single close button** in the notes dialog via a `hideClose` prop on `dialog.tsx` (opt-outs: NoteSheet, MarkdownPreviewModal, ShortcutsHelp) — cherry-pick of `b18b802`.
- **Note drawer opens instantly** — new `animation: none;` on `.shell-note-sheet`; the 400ms slide-in from the TUI branch is deliberately not carried over.

## Verification

- Spec-compliance review: cherry-picks byte-identical to originals; no keyframes/slide-in anywhere in the diff.
- Code-quality review: approved (unlayered `animation: none` reliably overrides the Tailwind utility layer; close/unmount unaffected).
- Unit suite: 1303/1303 passing; `electron-vite build` clean.
- Manual smoke of all five fixes in the preview app: confirmed.

Known follow-up (pre-existing, out of scope): the dialog backdrop keeps shadcn's stock ~150ms fade because `.shell-note-sheet__overlay` is orphaned — `DialogContent` mounts its own overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)