### PR TITLE
chore: relicense from MIT to FSL-1.1-ALv2 and add contributor CLA

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,133 @@
+# Contributor License Agreement
+
+Thank you for your interest in contributing to ai-14all (the "Project"),
+maintained by Vu Phan ("We" or "Us").
+
+This Contributor License Agreement ("Agreement") sets out the terms under which
+your contributions are accepted into the Project. It protects you, Us, and the
+Project's users, and it lets Us offer the Project under more than one license —
+including future commercial editions — while you keep the copyright to your
+work. Please read it carefully before contributing.
+
+This Agreement is adapted from the Apache Software Foundation Individual
+Contributor License Agreement. It is provided as a template and is **not legal
+advice**; consult your own counsel about its effect.
+
+## 1. Definitions
+
+**"You"** (or **"Your"**) means the individual who submits a Contribution to Us,
+or the legal entity authorized by the copyright owner to submit it. For a legal
+entity, the entity making a Contribution and all other entities that control,
+are controlled by, or are under common control with that entity are considered a
+single Contributor.
+
+**"Contribution"** means any original work of authorship, including any
+modifications or additions to an existing work, that is intentionally submitted
+by You to Us for inclusion in, or documentation of, the Project. "Submitted"
+means any form of electronic, verbal, or written communication sent to Us or
+Our representatives, including but not limited to communication on electronic
+mailing lists, source code control systems, and issue tracking systems that are
+managed by, or on behalf of, Us — but excluding communication that is
+conspicuously marked or otherwise designated in writing by You as "Not a
+Contribution."
+
+## 2. Grant of Copyright License
+
+Subject to the terms of this Agreement, You hereby grant to Us and to recipients
+of software distributed by Us a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable copyright license to reproduce, prepare derivative
+works of, publicly display, publicly perform, sublicense, and distribute Your
+Contributions and such derivative works.
+
+## 3. Grant of Patent License
+
+Subject to the terms of this Agreement, You hereby grant to Us and to recipients
+of software distributed by Us a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license to
+make, have made, use, offer to sell, sell, import, and otherwise transfer the
+Project, where such license applies only to those patent claims licensable by
+You that are necessarily infringed by Your Contribution alone or by combination
+of Your Contribution with the Project to which such Contribution was submitted.
+
+If any entity institutes patent litigation against You or any other entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that Your
+Contribution, or the Project to which You have contributed, constitutes direct
+or contributory patent infringement, then any patent licenses granted to that
+entity under this Agreement for that Contribution or Project shall terminate as
+of the date such litigation is filed.
+
+## 4. Right to Relicense
+
+You acknowledge and agree that We may license and distribute Your Contributions,
+and any derivative works of them, under **any license terms We choose**,
+including the Functional Source License, the Apache License 2.0, any other
+open-source or source-available license, **and proprietary or commercial license
+terms** — and We may do so without any obligation of accounting or payment to
+You. This Section 4 is the mechanism by which the Project can offer commercial
+editions; it does not transfer Your copyright, which You retain.
+
+## 5. Your Representations
+
+You represent that:
+
+1. You are legally entitled to grant the above licenses.
+
+2. Each of Your Contributions is Your original creation, or You otherwise have
+   the right to submit it under the terms of this Agreement.
+
+3. If Your employer(s) have rights to intellectual property that You create that
+   includes Your Contributions, You have received permission to make
+   Contributions on behalf of that employer, that Your employer has waived such
+   rights for Your Contributions to Us, or that Your employer has executed a
+   separate agreement with Us.
+
+4. Your Contribution does not knowingly violate any third party's copyrights,
+   trademarks, patents, or other intellectual property rights.
+
+You agree to notify Us of any facts or circumstances of which You become aware
+that would make these representations inaccurate in any respect.
+
+## 6. Third-Party Works
+
+Should You wish to submit work that is not Your original creation, You may submit
+it to Us separately from any Contribution, identifying the complete details of
+its source and of any license or other restriction (including, but not limited
+to, related patents, trademarks, and license agreements) of which You are
+personally aware, and conspicuously marking the work as "Submitted on behalf of
+a third-party: [named here]".
+
+## 7. No Obligation
+
+You understand that the decision to include Your Contribution in any project or
+source repository is entirely at Our discretion, and this Agreement does not
+obligate Us to use or incorporate Your Contributions.
+
+## 8. Disclaimer
+
+Unless required by applicable law or agreed to in writing, You provide Your
+Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied, including, without limitation, any warranties or
+conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE.
+
+## How to Sign
+
+By submitting a pull request, patch, or other Contribution to the Project, you
+agree to the terms of this Agreement for that and all of your Contributions.
+
+To make your agreement explicit on each Contribution, add a `Signed-off-by`
+trailer to your commits using your real name and email:
+
+```
+git commit -s
+```
+
+which appends:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+We may additionally require agreement to be recorded through an automated
+CLA-checking service (for example, the CLA Assistant GitHub app) before a pull
+request can be merged.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,105 @@
-MIT License
+# Functional Source License, Version 1.1, ALv2 Future License
 
-Copyright (c) 2026 Vu Phan
+## Abbreviation
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+FSL-1.1-ALv2
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+## Notice
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Copyright 2026 Vu Phan
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ai-14all
 
-[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
+[![License: FSL-1.1-ALv2](https://img.shields.io/badge/license-FSL--1.1--ALv2-blue.svg)](./LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/ai-creed/ai-14all?display_name=tag)](https://github.com/ai-creed/ai-14all/releases)
 [![macOS arm64](https://img.shields.io/badge/macOS-arm64-informational)](#install)
 
@@ -104,6 +104,24 @@ pnpm format
 pnpm package:mac  # local unsigned macOS build
 ```
 
+## Contributing
+
+Contributions are welcome. Because ai-14all may offer commercial editions, every
+contributor must agree to the [Contributor License Agreement](./CLA.md) before
+their first contribution is merged — it lets the project relicense your work
+(including under future commercial terms) while you retain copyright to it.
+
 ## License
 
-MIT — see [LICENSE](./LICENSE).
+[Functional Source License 1.1, Apache 2.0 Future License](./LICENSE)
+(`FSL-1.1-ALv2`).
+
+You may use, copy, modify, and redistribute ai-14all for any purpose **except a
+Competing Use** — broadly, making it (or substantially similar functionality)
+available to others in a commercial product or service that competes with
+ai-14all. Internal use, non-commercial education, and non-commercial research
+are always permitted. Two years after each version is released, that version
+automatically converts to the Apache License 2.0.
+
+FSL is **source-available**, not an OSI-approved "open source" license. See
+[fsl.software](https://fsl.software) for the rationale and FAQ.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"private": true,
 	"description": "Mission-control desktop app for running AI coding agents in parallel across Git worktrees",
 	"author": "Vu Phan <vu.phan.se@gmail.com>",
+	"license": "FSL-1.1-ALv2",
 	"homepage": "https://ai-creed.dev/projects/ai-14all/",
 	"packageManager": "pnpm@10.33.0",
 	"type": "module",


### PR DESCRIPTION
## Summary

Switches ai-14all from the **MIT License** to the **Functional Source License 1.1 with an Apache-2.0 future grant** (`FSL-1.1-ALv2`), and adds a Contributor License Agreement.

Rationale: the project is growing into a real product. FSL keeps it **source-available and free for any non-competing use**, but prevents a third party from reselling it as a competing commercial product. Each released version automatically converts to **Apache-2.0 two years** after publication, so the community still gets a fully open future. The CLA preserves the ability to offer commercial editions later.

> **Branch base:** intentionally branched from `origin/master`, *not* local `master`, so the in-progress power-feature work is excluded from this PR.

## Changes

- **`LICENSE`** — replaced MIT text with the canonical FSL-1.1-ALv2 text (Copyright 2026 Vu Phan).
- **`package.json`** — added `"license": "FSL-1.1-ALv2"` (the field did not previously exist).
- **`README.md`** — updated the license badge and License section; added a Contributing section pointing to the CLA.
- **`CLA.md`** — new Contributor License Agreement (adapted from the Apache ICLA) with an explicit relicensing grant so contributions can be included in future commercial editions, plus a sign-off mechanism.

## Important notes

- **Past releases stay MIT.** Versions already published under MIT remain available under MIT; this change applies to future versions only.
- **Not OSI "open source."** FSL is source-available. GitHub may stop showing a recognized license label, and the `FSL-1.1-ALv2` value in `package.json` is not an SPDX-listed identifier (cosmetic only — the package is `private` and unpublished).
- **CLA enforcement is not yet automated.** The CLA documents agreement via commit sign-off; wiring up a CLA-check bot (e.g. CLA Assistant) is a follow-up.
- **Not legal advice.** Recommend a lawyer review the CLA and the relicensing strategy before relying on them.

## Verification

- `package.json` validated as parseable JSON; `license` resolves to `FSL-1.1-ALv2`.
- `prettier --check README.md CLA.md` → passes (LICENSE is extensionless, so prettier skips it; canonical text preserved).
- No source files changed → lint / typecheck / tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)