### PR TITLE
fix(shortcuts): allow Cmd+/ and Cmd+Shift+P to fire from terminal pane

### DIFF
--- a/src/app/shortcut-registry.ts
+++ b/src/app/shortcut-registry.ts
@@ -82,12 +82,17 @@ function isShortcutsHelpShortcut(
 		!e.ctrlKey &&
 		!e.altKey;
 	if (keyIsShiftP) {
-		return !targetOwnsTyping(e.target as HTMLElement | null);
+		// allowXterm: global navigation shortcut — terminal binds no Cmd+Shift+P.
+		return !targetOwnsTyping(e.target as HTMLElement | null, {
+			allowXterm: true,
+		});
 	}
 	// ⌘/ or ⌘? / Ctrl+/ or Ctrl+?
 	const keyIsHelp = e.key === "?" || e.key === "/";
 	if (!keyIsHelp) return false;
-	if (targetOwnsTyping(e.target as HTMLElement | null)) return false;
+	// allowXterm: global navigation shortcut — terminal binds no Cmd+/ or Cmd+?.
+	if (targetOwnsTyping(e.target as HTMLElement | null, { allowXterm: true }))
+		return false;
 	if (platform === "mac") return e.metaKey && !e.ctrlKey && !e.altKey;
 	return e.ctrlKey && !e.metaKey && !e.altKey;
 }

--- a/tests/unit/app/shortcut-registry.test.ts
+++ b/tests/unit/app/shortcut-registry.test.ts
@@ -240,10 +240,15 @@ describe("terminal-first ownership — all shortcuts", () => {
 	};
 
 	// Shortcuts that must fire even when focus is inside the terminal pane.
-	// Cmd+P (Files) and Cmd+J (Review) are global navigation, not terminal input.
-	const xtermShouldFire = new Set(["files-overlay", "review.open"]);
+	// Cmd+P (Files), Cmd+J (Review), and Cmd+/ (Shortcuts help) are global
+	// navigation — the terminal binds none of these keys.
+	const xtermShouldFire = new Set([
+		"files-overlay",
+		"review.open",
+		"shortcuts-help",
+	]);
 
-	it("only files-overlay and review.open fire when focus is inside .xterm; the rest stay blocked", () => {
+	it("only files-overlay, review.open and shortcuts-help fire when focus is inside .xterm; the rest stay blocked", () => {
 		const target = xtermTarget();
 		for (const id of Object.keys(macTriggers)) {
 			const s = entry(id);


### PR DESCRIPTION
## Summary

- `isShortcutsHelpShortcut` was missing `{ allowXterm: true }` on both its `targetOwnsTyping` calls
- When the terminal held focus, `Cmd+/` and `Cmd+Shift+P` were silently swallowed by the xterm guard
- Both are global navigation shortcuts — the terminal binds neither key — so they should fire exactly like `Cmd+P` (files-overlay) and `Cmd+J` (review.open), which already use `allowXterm: true`

## Root cause

The xterm focus guard in `targetOwnsTyping` returns `true` (owns typing) when `target.closest(".xterm")` matches. Without `allowXterm: true`, the predicate short-circuits and the shortcut never reaches its handler.

A side-effect of the missing flag: after opening the Files overlay with `Cmd+P` and closing it with Escape, Radix Dialog returned focus to `document.body` (not back to the terminal), which incidentally made `Cmd+/` work — masking the bug until terminal focus was tested directly.

## Test plan

- [ ] With terminal focused, press `Cmd+/` → shortcuts help opens
- [ ] With terminal focused, press `Cmd+Shift+P` (Mac) → shortcuts help opens  
- [ ] `Cmd+P` and `Cmd+J` still fire from terminal (unchanged behaviour)
- [ ] `Cmd+/` still blocked inside a text input or Monaco editor
- [ ] Unit test updated: `xtermShouldFire` set now includes `"shortcuts-help"`; all 1991 tests pass