### PR TITLE
Workspace panel rework — git-tree worktree navigator

### DIFF
--- a/docs/design-specs/2026-06-24-workspace-panel-rework-design.md
+++ b/docs/design-specs/2026-06-24-workspace-panel-rework-design.md
@@ -1,0 +1,259 @@
+# Spec: Workspace Panel Rework — Git-Tree Worktree Navigator
+
+**Status:** Design approved (2026-06-24) via an interactive prototype iterated with the
+user. Not yet implemented.
+**Scope:** Restructure the left **Workspace** sidebar from a flat worktree list into a
+collapsible **repo → worktree git tree**, with a unified icon set, a tightened typography
+ladder, a solid 2px tree rail, and a palette-based theme switcher.
+**Reference prototype:** `docs/design-specs/2026-06-24-workspace-panel-rework-prototype.html`
+(self-contained, on the app's real tokens — open in a browser to see every interaction).
+**Source of the target design:** user mockup (see commit image history) of the desired
+panel.
+
+## 1. Goal
+
+The Workspace panel today renders each repo ("workspace group") as a chromeless section
+with a **flat, always-visible list** of bordered worktree cards — no tree connectors, no
+per-repo collapse, scattered font sizes, and a settings affordance that doesn't read as
+"theme." The mockup asks for a proper **file-tree** presentation: each repo is a
+collapsible node, its worktrees hang off a vertical rail with `├─`/`└─` elbows, and the
+chrome (icons, type scale, bottom bar) is consistent and legible.
+
+This rework is **structural** — the tree, typography ladder, icon unification, and layout
+land in `shell.css` + the panel components, so **all four themes** (dark/light/warm/tui)
+benefit. Color comes from the existing per-theme tokens; nothing here is palette-specific
+except the new `--rail` token, which is defined once per theme.
+
+The existing TUI spec already lists `marker-tree` for `WorktreeTree` as
+*specced-but-not-built* (`docs/design-specs/tui-css-spec.md` §12.2); this spec supersedes
+and concretizes that line item.
+
+## 2. Current state → gap
+
+| Area | Today | Target |
+|---|---|---|
+| Hierarchy | Flat list of worktree cards under a chromeless repo section (`SessionSidebar.tsx`) | 2-depth tree: repo node → worktree rows on a rail |
+| Repo header | Plain name button, no expander | Chevron + git-branch icon + UPPERCASE name; collapsible |
+| Connectors | None | 2px **solid** CSS rail + square `├─`/`└─` elbows |
+| Remove workspace | Close affordance exists in `WorkspaceSwitcher` | `×` on the repo title, **revealed on hover** |
+| Worktree row | Rich card (branch, path, chips, process dot); active row bordered + `×` | Unchanged content, re-parented under the rail |
+| Typography | 16/17px name, 14px title, 13px branch, 0.7rem chips (scattered) | One `--ws-fs-*` ladder |
+| Bottom bar | "Load workspace" + a gear | "Load workspace" + **palette** theme switcher |
+| Collapsed panel | Letter badges with borders | Centered git-icon **+ initial**, no borders, even padding |
+
+## 3. Design decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| D1 | **Option A** tree rendering: 2px solid CSS rail + square elbows | Crisp like the mockup, reflows with variable-height rich rows, themeable via one token, square corners match the radius-0 design system. (Rejected: B box-drawing glyphs — heavier, font-dependent; C indent-guide only — loses the "connects to item" read.) |
+| D2 | Tree is **2 depths only** (repo → worktree) | The data model is workspace(repo) → worktrees; no deeper nesting exists. |
+| D3 | **Every worktree renders as a rich row**; chips degrade gracefully when there's no session | User chose "always rich rows." Discovered/unloaded repos (no provider/state) show branch + path only — see CAPSTONE-IELTS in the prototype. |
+| D4 | Repo groups are **collapsible and persisted** | Matches the chevron in the mockup; collapse state survives restart. |
+| D5 | **Keep filled provider pills** (e.g. `claude` on amber); retune spacing only | User choice. Deliberate deviation from the mockup's dot+label provider — see §15. |
+| D6 | **Unify all panel icons** on the Nerd Font `<Icon>` registry | "Replace icons to stay consistent with others." Adds `git-branch` + `palette`; reuses `caret-*`, `close`, `dot`, `plus`. |
+| D7 | Bottom gear → **palette** icon, opens a theme menu | A palette reads as "pick a visual theme" better than a settings gear (4 color themes, not light/dark). |
+| D8 | New **solid** `--rail` token per theme (no alpha) | User: "hairline should be solid color without opacity." `--border` carries alpha in dark; a dedicated solid token keeps the rail crisp and tunable. |
+| D9 | CTAs ("+ New worktree", "Load workspace") sized at `--ws-fs-branch` (13px) | User-selected after trying header/repo sizes. |
+
+## 4. Information architecture
+
+```
+WORKSPACE                                   [◧ collapse panel]
+│
+├─ ▾  ⎇ AI-14ALL                            [× on title hover]   ← repo node (depth 0)
+│     ├─ master            [× when active]   ← worktree row (depth 1, boxed when active)
+│     │     tui-polish-1
+│     │     [claude] ● CL active
+│     ├─ product-document
+│     │     main
+│     │     [claude] ● stale
+│     └─ + New worktree                       ← last node on the rail (loaded repos only)
+│  ── separator ──
+└─ ▾  ⎇ CAPSTONE-IELTS                                            ← unloaded repo
+      ├─ master
+      │     main                              ← rich row, no chips (no session)
+      └─ product-document
+            main
+                                             [ Load workspace ]   [palette ⊕]
+```
+
+- **Repo node**: `role="treeitem" aria-expanded`. Clicking the header (or chevron)
+  toggles collapse. A hover-revealed `×` removes the workspace.
+- **Worktree rows**: inside `role="group"`. Selecting one moves the bordered box + close
+  `×` to it. `+ New worktree` is the last child on the rail (loaded repos), so it carries
+  the `└─` elbow.
+- A flat 1px `--border` separator sits between repo groups (replaces today's gradient
+  `::before` divider).
+
+## 5. Typography ladder — `tokens.css`
+
+New workspace-scoped tokens (layered on the existing `--font-size-body: 13px`):
+
+```css
+:root {
+  --ws-fs-header: 11px;   /* "WORKSPACE" panel title  — 600, uppercase, tracking .12em, --muted-foreground */
+  --ws-fs-repo:   15px;   /* repo name                — 700, uppercase, tracking .04em, --foreground */
+  --ws-fs-branch: 13px;   /* worktree branch + CTAs   — 600, --foreground */
+  --ws-fs-path:   12px;   /* path subtitle            — 400, --muted-foreground */
+  --ws-fs-chip:   11px;   /* provider pill + state    — 500/600 */
+}
+```
+
+This consolidates today's scattered values (`shell.css` repo name 16/17px, worktree title
+14px, branch 13px, chips 0.7rem). **CTAs use `--ws-fs-branch` (13px)** (D9).
+
+## 6. Tree rail — `shell.css`
+
+Locked geometry from the prototype. The trunk is centered on the chevron: the header has
+`padding-left: 4px` and the chevron is a `12px`, `text-align:center` box, so the chevron's
+center sits at **x = 10px**; the 2px trunk is drawn at `left: 9px` (spanning 9–11px,
+center 10px). Worktree rows sit inside `.ws-repo__children` (no horizontal padding) so
+their left edge aligns with the header's.
+
+```css
+/* Each worktree row + the New-worktree button is wrapped in a .ws-node */
+.ws-node { position: relative; padding-left: 24px; }
+
+/* vertical trunk (2px solid, centered on the chevron at x=10) */
+.ws-node::before {
+  content: ""; position: absolute; left: 9px; top: 0; bottom: 0;
+  border-left: 2px solid var(--rail);
+}
+/* last child stops the trunk at the elbow -> └─ */
+.ws-node:last-child::before { bottom: auto; height: 18px; }
+
+/* horizontal elbow, aligned to the branch-name line */
+.ws-node::after {
+  content: ""; position: absolute; left: 9px; top: 17px;
+  width: 13px; height: 2px; background: var(--rail);
+}
+```
+
+### 6.1 Solid `--rail` token (D8) — `tokens.css`, one per theme block
+
+```css
+[data-theme="dark"], :root { --rail: oklch(0.42 0.02 256); }
+[data-theme="light"]      { --rail: oklch(0.80 0.012 256); }
+[data-theme="warm"]       { --rail: #6b5d48; }
+[data-theme="tui"]        { --rail: oklch(0.44 0.015 240); }
+```
+
+(Implementation note: in the prototype the four theme blocks precede `:root`; because
+attribute selectors and `:root` have equal specificity, `--rail` is defined **only** in
+the theme blocks so a later `:root` rule can't override them. In `tokens.css` the dark
+defaults live in `:root`, so put dark's `--rail` there and the others in their
+`[data-theme]` blocks.)
+
+## 7. Icons — `src/components/ui/icon.tsx`
+
+Route every panel icon through `<Icon>`; extend `ICON_GLYPHS`:
+
+- **Add** `git-branch` (repo header + collapsed rail) and `palette` (bottom theme
+  switcher). Pick Nerd Font codepoints from the bundled Symbols Nerd Font — candidates:
+  `git-branch` → nf-oct-git_branch (`󰈥` / ``), `palette` → nf-oct-paintbrush
+  or nf-md-palette (``). Each entry keeps a text `fallback` per the registry contract.
+- **Reuse** `caret-down`/`caret-right` (chevron), `close` (`×`), `dot` (status), `plus`.
+- The registry already has `gear`; it is **replaced at the call site** by `palette` for
+  the theme switcher (D7) — do not remove `gear` (other call sites may use it).
+
+The prototype draws `git-branch` and `palette` as inline SVG only because Nerd Font isn't
+guaranteed in a bare browser; in-app they are Nerd Font glyphs via `<Icon>`.
+
+## 8. Status chips — `shell.css`
+
+Unchanged rendering, retuned to the ladder (D5):
+
+- **Provider**: filled pill `.shell-sidebar__provider-badge[data-provider=…]` — `claude`
+  amber (`--provider-claude`), `codex` blue, etc. (`background: color-mix(... 14%)`,
+  `color: <provider>`). Set `font-size: var(--ws-fs-chip)`.
+- **Process state**: 6px `.shell-sidebar__process-indicator[data-state=…]` dot —
+  `active` = `--warning`, `idle` = muted, `actionRequired` = `--danger` (pulsing halo),
+  `exited` = hollow. Paired with a `--ws-fs-chip` label ("CL active", "stale").
+- Provider pill + state dot+label share one row under the path with `gap` ≈ 10px.
+
+## 9. Collapse behavior + persistence
+
+- Chevron rotates (`▾` open → `▸` collapsed via `transform: rotate(-90deg)`).
+- Collapsing hides `.ws-repo__children`.
+- **Persistence**: store the set of collapsed repo IDs in the workspace state
+  (`src/features/workspace/logic/workspace-state.ts` reducer, backed by the app's
+  better-sqlite3 / settings persistence) so it survives restart. (The prototype uses
+  `localStorage` as a stand-in.)
+
+## 10. Collapsed panel (mini-rail) — `SidebarPanel.tsx`
+
+When the panel is collapsed (`◧` top-right):
+
+- Width ~56px; header and footer center their single icon (`justify-content: center`).
+- Each workspace shows the **git icon + first initial side by side** (row layout,
+  `gap: 5px`), centered, **no borders**, clicking expands the panel.
+- The mini list has **even top/bottom padding** (`18px 0`, `gap: 18px`) so the last
+  workspace matches the rest.
+- All icons (top collapse, repo icons, bottom palette) share the centered vertical column.
+
+Reconcile with the existing `WorkspaceSwitcher.tsx` (today's compact letter-badge view) —
+this becomes its rendering.
+
+## 11. Theme switcher — `SidebarPanel.tsx` + `use-theme.ts`
+
+- "Load workspace" CTA stays; beside it the **palette** icon opens a theme menu
+  (dark / light / warm / tui) rendered with the shadcn dropdown-menu, driving the existing
+  `src/lib/use-theme.ts`. The active theme is checkmarked.
+
+## 12. Component / file changes
+
+| File | Change |
+|---|---|
+| `src/features/workspace/components/SessionSidebar.tsx` | Tree restructure (repo node → `.ws-node` rows), chevron + git icon header, hover `×` remove-workspace, `role=tree/treeitem/group` + `aria-expanded`, rail markup |
+| `src/app/components/SidebarPanel.tsx` | Collapsed mini-rail (icon + initial, centered, even padding), bottom palette theme switcher |
+| `src/features/workspace/components/WorkspaceSwitcher.tsx` | Folded into the collapsed mini-rail rendering |
+| `src/components/ui/icon.tsx` | Add `git-branch` + `palette` to `ICON_GLYPHS` |
+| `src/app/shell.css` | Rail CSS (§6), typography ladder application, repo separator, chip spacing, collapsed centering, CTA sizes |
+| `src/styles/tokens.css` | `--ws-fs-*` tokens (§5), solid `--rail` per theme (§6.1) |
+| `src/features/workspace/logic/workspace-state.ts` | Persisted per-repo collapse state |
+| `src/lib/use-theme.ts` | Reused by the palette switcher (no API change expected) |
+
+## 13. Accessibility
+
+- Rails/elbows are decorative — drawn via `::before`/`::after`, no DOM nodes, not announced.
+- Tree semantics: `role="tree"` on the container, `role="treeitem" aria-expanded` on repo
+  headers, `role="group"` on `.ws-repo__children`.
+- Repo `×` and worktree `×` are real buttons (or `role="button"` with key handlers) with
+  `aria-label`; `stopPropagation` so they don't toggle collapse/selection.
+- Keep `focus-visible` outlines (per `tui-css-spec.md` D6). Hover-revealed `×` must also
+  appear on `:focus-within` (already in the prototype).
+
+## 14. Testing
+
+- **Vitest**: tree renders repo → worktree hierarchy; collapse toggles + persists;
+  last-child gets the `└─` (trunk-stop) treatment; rich row degrades to branch+path when
+  no session; icon registry contains `git-branch` + `palette`; repo `×` removes a
+  workspace.
+- **Playwright screenshots**: add Workspace-panel captures (expanded + collapsed) per
+  theme into `tests/__screenshots__/`, extending the existing gallery flow, for
+  before/after review.
+
+## 15. Deviations from the mockup (deliberate)
+
+- **Provider chip**: the mockup shows `● claude` as a dot+label; we keep the existing
+  **filled amber pill** (D5, user's call). Session-state/staleness stays dot+label.
+- **Repo icon**: the mockup's diamond `◈` is replaced by a **git-branch** glyph
+  (user request).
+- **Bottom-right icon**: gear → **palette** (D7).
+
+## 16. Out of scope / open questions
+
+- No deeper-than-2 nesting; no drag-reorder of worktrees.
+- `+ New worktree` shown under **loaded** repos only (matches mockup); confirm whether
+  unloaded/discovered repos should also offer it.
+- Exact Nerd Font codepoints for `git-branch`/`palette` to be confirmed against the
+  bundled Symbols Nerd Font at implementation time (§7).
+- Whether the collapse-state store should be per-workspace or global is left to the
+  reducer design.
+
+## 17. Reference prototype
+
+`docs/design-specs/2026-06-24-workspace-panel-rework-prototype.html` is the approved,
+fully-interactive reference (real tokens; A/B/C tree toggle; theme switch; collapse,
+select, close, add-worktree, remove-workspace, panel-collapse interactions). It is the
+visual source of truth for spacing and the locked Option-A geometry above.

--- a/docs/design-specs/2026-06-24-workspace-panel-rework-prototype.html
+++ b/docs/design-specs/2026-06-24-workspace-panel-rework-prototype.html
@@ -1,0 +1,644 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Workspace panel — git-tree tryout</title>
+<style>
+/* ============================================================
+   Token blocks mirrored verbatim from src/styles/tokens.css
+   + provider colors from src/app/shell.css (lines 55-57/76-78/113-115)
+   ============================================================ */
+[data-theme="dark"] {
+  --background: oklch(0.129 0.042 264.695);
+  --foreground: oklch(0.984 0.003 247.858);
+  --card: oklch(0.208 0.042 265.755);
+  --popover: oklch(0.208 0.042 265.755);
+  --muted: oklch(0.279 0.041 260.031);
+  --muted-foreground: oklch(0.704 0.04 256.788);
+  --primary: oklch(0.929 0.013 255.508);
+  --primary-foreground: oklch(0.208 0.042 265.755);
+  --border: oklch(1 0 0 / 10%);
+  --ring: oklch(0.551 0.027 264.364);
+  --rail: oklch(0.42 0.02 256);            /* solid tree-rail line */
+  --warning: oklch(0.828 0.122 75);
+  --danger: oklch(0.704 0.191 22.216);
+  --provider-claude: #d97706;
+  --provider-codex: #2563eb;
+}
+[data-theme="light"] {
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.129 0.042 264.695);
+  --card: oklch(1 0 0);
+  --popover: oklch(1 0 0);
+  --muted: oklch(0.968 0.007 247.896);
+  --muted-foreground: oklch(0.42 0.046 257.417);
+  --primary: oklch(0.208 0.042 265.755);
+  --primary-foreground: oklch(0.984 0.003 247.858);
+  --border: oklch(0.929 0.013 255.508);
+  --ring: oklch(0.55 0.04 256.788);
+  --rail: oklch(0.80 0.012 256);           /* solid tree-rail line */
+  --warning: oklch(0.43 0.14 60);
+  --danger: oklch(0.45 0.24 27.325);
+  --provider-claude: #b45309;
+  --provider-codex: #1d4ed8;
+}
+[data-theme="warm"] {
+  --background: #221c15;
+  --foreground: #f6efe4;
+  --card: #2a231b;
+  --popover: #342c22;
+  --muted: #3d2817;
+  --muted-foreground: #cab999;
+  --primary: #e58a5e;
+  --primary-foreground: #221c15;
+  --border: #4a3f31;
+  --ring: #9a8266;
+  --rail: #6b5d48;                          /* solid tree-rail line */
+  --warning: #dda85e;
+  --danger: #d97058;
+  --provider-claude: #e58a5e;
+  --provider-codex: #5a9bd6;
+}
+[data-theme="tui"] {
+  --background: oklch(0.16 0.015 240);
+  --foreground: oklch(0.96 0.01 200);
+  --card: oklch(0.2 0.015 240);
+  --popover: oklch(0.2 0.015 240);
+  --muted: oklch(0.26 0.015 240);
+  --muted-foreground: oklch(0.68 0.02 230);
+  --primary: oklch(0.78 0.13 175);
+  --primary-foreground: oklch(0.16 0.015 240);
+  --border: oklch(0.34 0.015 240);
+  --ring: oklch(0.78 0.13 175);
+  --rail: oklch(0.44 0.015 240);            /* solid tree-rail line */
+  --warning: oklch(0.828 0.122 75);
+  --danger: oklch(0.704 0.191 22.216);
+  --provider-claude: #d97706;
+  --provider-codex: #2563eb;
+}
+
+:root {
+  /* Workspace typography ladder proposed in the spec */
+  --ws-fs-header: 11px;
+  --ws-fs-repo: 15px;
+  --ws-fs-branch: 13px;
+  --ws-fs-path: 12px;
+  --ws-fs-chip: 11px;
+  --font-ui: "SF Mono", "SFMono-Regular", ui-monospace, Menlo, Monaco, monospace;
+  /* --rail is defined per theme below as a SOLID color (no alpha). */
+}
+
+* { box-sizing: border-box; }
+html, body { height: 100%; }
+body {
+  margin: 0;
+  font-family: var(--font-ui);
+  font-size: 13px;
+  background: var(--background);
+  color: var(--foreground);
+  display: flex;
+  gap: 28px;
+  padding: 24px;
+  align-items: flex-start;
+}
+
+/* ---------------- Controls column ---------------- */
+.controls {
+  width: 280px;
+  flex-shrink: 0;
+  font-size: 12px;
+  line-height: 1.5;
+}
+.controls h1 { font-size: 15px; margin: 0 0 4px; letter-spacing: .02em; }
+.controls .sub { color: var(--muted-foreground); margin: 0 0 18px; }
+.controls .group { margin-bottom: 18px; }
+.controls .group > .lbl {
+  text-transform: uppercase;
+  letter-spacing: .08em;
+  font-size: 10px;
+  color: var(--muted-foreground);
+  margin-bottom: 7px;
+}
+.segmented { display: flex; flex-direction: column; gap: 6px; }
+.segmented button {
+  font: inherit;
+  text-align: left;
+  padding: 8px 10px;
+  background: var(--card);
+  color: var(--foreground);
+  border: 1px solid var(--border);
+  cursor: pointer;
+  line-height: 1.35;
+}
+.segmented button .opt-name { font-weight: 700; }
+.segmented button .opt-desc { display: block; color: var(--muted-foreground); font-size: 11px; margin-top: 2px; }
+.segmented button[aria-pressed="true"] {
+  border-color: var(--primary);
+  outline: 1px solid var(--primary);
+}
+.segmented.row { flex-direction: row; flex-wrap: wrap; }
+.segmented.row button { flex: 1 1 0; text-align: center; padding: 6px 8px; }
+.hint { color: var(--muted-foreground); font-size: 11px; }
+.hint code { background: var(--muted); padding: 1px 4px; }
+.reset {
+  font: inherit; cursor: pointer; margin-top: 4px;
+  background: transparent; color: var(--muted-foreground);
+  border: 1px solid var(--border); padding: 6px 10px;
+}
+.reset:hover { color: var(--foreground); border-color: var(--ring); }
+.recommend { color: var(--primary); font-weight: 700; }
+
+/* ---------------- The panel ---------------- */
+.panel {
+  width: 320px;
+  flex-shrink: 0;
+  background: var(--background);
+  border: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  height: 760px;
+  position: relative;
+  transition: width .14s ease;
+}
+.panel.collapsed { width: 56px; }
+
+.panel__header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 14px 14px 12px;
+  border-bottom: 1px solid var(--border);
+}
+.panel.collapsed .panel__header { justify-content: center; padding: 14px 0 12px; }
+.panel.collapsed .panel__footer { justify-content: center; padding: 12px 0; }
+.panel__title {
+  font-size: var(--ws-fs-header);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .12em;
+  color: var(--muted-foreground);
+}
+.panel.collapsed .panel__title,
+.panel.collapsed .panel__body,
+.panel.collapsed .panel__footer-text { display: none; }
+.iconbtn {
+  font: inherit; cursor: pointer; background: transparent; color: var(--muted-foreground);
+  border: 0; padding: 4px; line-height: 1; border-radius: 0;
+  display: inline-flex; align-items: center; justify-content: center;
+}
+.iconbtn:hover { color: var(--foreground); }
+
+.panel__body { flex: 1; overflow-y: auto; padding: 12px 12px 4px; }
+
+/* collapsed rail mini-view: git icon + initial, centered, no borders, even padding */
+.mini { display: none; flex-direction: column; align-items: center; gap: 18px; padding: 18px 0; }
+.panel.collapsed .mini { display: flex; }
+.mini .badge {
+  display: flex; flex-direction: row; align-items: center; gap: 5px;
+  color: var(--muted-foreground); cursor: pointer;
+}
+.mini .badge .mini-initial { font-weight: 700; font-size: 12px; color: var(--foreground); }
+.mini .badge:hover { color: var(--foreground); }
+.mini .badge:hover .mini-initial { color: var(--foreground); }
+
+/* ---------------- Repo group ---------------- */
+.ws-repo { margin-bottom: 6px; }
+.ws-repo__header {
+  display: flex; align-items: center; gap: 8px;
+  width: 100%; font: inherit; text-align: left;
+  background: transparent; border: 0; color: var(--foreground);
+  padding: 8px 4px; cursor: pointer;
+}
+/* chevron box is 12px wide, glyph centered -> its center sits at 4(pad)+6 = 10px,
+   exactly the x of the hairline rail (left:10px in .ws-node). */
+.ws-repo__chevron { color: var(--muted-foreground); width: 12px; text-align: center; display: inline-block; transition: transform .12s ease; font-size: 11px; }
+.ws-repo[data-collapsed="true"] .ws-repo__chevron { transform: rotate(-90deg); }
+.ws-repo__icon { color: var(--muted-foreground); display: inline-flex; align-items: center; }
+.ws-repo__name {
+  font-size: var(--ws-fs-repo); font-weight: 700;
+  text-transform: uppercase; letter-spacing: .04em;
+}
+/* remove-workspace ×: revealed only when the repo title row is hovered */
+.ws-repo__close {
+  margin-left: auto; cursor: pointer; color: var(--muted-foreground);
+  padding: 0 4px; line-height: 1; font-size: 14px;
+  opacity: 0; transition: opacity .12s ease;
+}
+.ws-repo__header:hover .ws-repo__close,
+.ws-repo__header:focus-within .ws-repo__close { opacity: 1; }
+.ws-repo__close:hover { color: var(--foreground); }
+.ws-repo__children { display: block; }
+.ws-repo[data-collapsed="true"] .ws-repo__children { display: none; }
+
+/* separator between repos */
+.ws-sep { height: 1px; background: var(--border); margin: 10px 4px 12px; }
+
+/* ---------------- Tree node + rails ---------------- */
+.ws-node { position: relative; padding-left: 24px; }
+
+/* --- Option A: square elbow (CSS), 2px rail centered on the chevron (x=10) --- */
+[data-tree="A"] .ws-node::before {            /* vertical trunk (2px wide -> 9..11, center 10) */
+  content: ""; position: absolute; left: 9px; top: 0; bottom: 0;
+  border-left: 2px solid var(--rail);
+}
+[data-tree="A"] .ws-node:last-child::before { bottom: auto; height: 18px; }  /* stop at elbow */
+[data-tree="A"] .ws-node::after {             /* horizontal elbow, aligned to branch line */
+  content: ""; position: absolute; left: 9px; top: 17px;
+  width: 13px; height: 2px; background: var(--rail);
+}
+
+/* --- Option B: box-drawing glyphs (true TUI), 2px rail --- */
+[data-tree="B"] .ws-node::after {             /* vertical trunk, crisp like A */
+  content: ""; position: absolute; left: 9px; top: 0; bottom: 0;
+  border-left: 2px solid var(--rail);
+}
+[data-tree="B"] .ws-node:last-child::after { bottom: auto; height: 18px; }
+[data-tree="B"] .ws-node::before {            /* glyph corner ├─ / └─ */
+  content: "\251C\2500"; position: absolute; left: 8px; top: 11px;
+  color: var(--rail); font-size: 14px; line-height: 1; letter-spacing: -1px;
+}
+[data-tree="B"] .ws-node:last-child::before { content: "\2514\2500"; }
+
+/* --- Option C: indent guide only (minimal), 2px rail --- */
+[data-tree="C"] .ws-node::before {            /* continuous trunk, no elbow */
+  content: ""; position: absolute; left: 9px; top: 0; bottom: 0;
+  border-left: 2px solid var(--rail);
+}
+[data-tree="C"] .ws-node { padding-left: 22px; }
+
+/* ---------------- Worktree row ---------------- */
+.ws-worktree {
+  display: block; width: 100%; text-align: left;
+  background: transparent; border: 1px solid transparent;
+  color: var(--foreground); font: inherit; cursor: pointer;
+  padding: 8px 10px; margin: 2px 0;
+}
+.ws-worktree:hover { background: color-mix(in oklab, var(--foreground) 5%, transparent); }
+.ws-worktree[data-selected="true"] {
+  border-color: var(--ring);
+  background: color-mix(in oklab, var(--foreground) 4%, transparent);
+}
+.ws-worktree__top { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.ws-worktree__branch { font-size: var(--ws-fs-branch); font-weight: 600; }
+.ws-worktree__close {
+  font: inherit; cursor: pointer; background: transparent; border: 0;
+  color: var(--muted-foreground); padding: 0 2px; line-height: 1; display: none;
+}
+.ws-worktree[data-selected="true"] .ws-worktree__close { display: inline-flex; }
+.ws-worktree__close:hover { color: var(--foreground); }
+.ws-worktree__path { font-size: var(--ws-fs-path); color: var(--muted-foreground); margin-top: 3px; }
+.ws-worktree__chips { display: flex; align-items: center; gap: 10px; margin-top: 7px; }
+
+.chip-provider {
+  display: inline-flex; align-items: center;
+  padding: 1px 6px; font-size: var(--ws-fs-chip); font-weight: 600;
+  letter-spacing: .3px; text-transform: lowercase;
+}
+.chip-provider[data-provider="claude"] { background: color-mix(in srgb, var(--provider-claude) 14%, transparent); color: var(--provider-claude); }
+.chip-provider[data-provider="codex"]  { background: color-mix(in srgb, var(--provider-codex) 14%, transparent);  color: var(--provider-codex); }
+
+.chip-state { display: inline-flex; align-items: center; gap: 6px; font-size: var(--ws-fs-chip); color: var(--muted-foreground); }
+.dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; background: var(--muted-foreground); }
+.dot[data-state="active"] { background: var(--warning); }
+.dot[data-state="idle"]   { background: var(--muted-foreground); }
+.dot[data-state="actionRequired"] { background: var(--danger); animation: dot-pulse 1.4s ease-in-out infinite; }
+.dot[data-state="exited"] { background: transparent; border: 1px solid var(--muted-foreground); }
+@keyframes dot-pulse {
+  0%,100% { box-shadow: 0 0 0 0 transparent; }
+  50% { box-shadow: 0 0 8px color-mix(in srgb, var(--danger) 80%, transparent); }
+}
+
+/* + New worktree (last node on the rail) */
+.ws-newtree {
+  display: block; width: 100%; font: inherit; cursor: pointer;
+  font-size: var(--ws-fs-branch);              /* CTA matches the branch (worktree) title size */
+  background: var(--card); color: var(--foreground);
+  border: 1px solid var(--border); padding: 9px 10px; margin: 4px 0 2px;
+  text-align: center;
+}
+.ws-newtree:hover { border-color: var(--ring); }
+
+/* ---------------- Footer ---------------- */
+.panel__footer {
+  display: flex; align-items: center; gap: 8px;
+  padding: 12px; border-top: 1px solid var(--border);
+}
+.btn-load {
+  flex: 1; font: inherit; cursor: pointer;
+  font-size: var(--ws-fs-branch);              /* CTA matches the branch (worktree) title size */
+  background: var(--card); color: var(--foreground);
+  border: 1px solid var(--border); padding: 11px 10px; font-weight: 600;
+}
+.btn-load:hover { border-color: var(--ring); }
+.gear-wrap { position: relative; }
+.gear {
+  font: inherit; cursor: pointer; background: transparent; border: 1px solid transparent;
+  color: var(--muted-foreground); width: 36px; height: 38px;
+  display: grid; place-items: center;
+}
+.gear svg { display: block; }
+.gear:hover { color: var(--foreground); border-color: var(--border); }
+.gear.spin { animation: gear-pop .35s ease; }
+@keyframes gear-pop { 50% { transform: scale(1.18); } }
+.theme-menu {
+  position: absolute; bottom: 44px; right: 0; min-width: 130px;
+  background: var(--popover); border: 1px solid var(--border);
+  display: none; flex-direction: column; z-index: 10;
+}
+.theme-menu.open { display: flex; }
+.theme-menu button {
+  font: inherit; text-align: left; cursor: pointer;
+  background: transparent; border: 0; color: var(--foreground); padding: 8px 12px;
+  display: flex; align-items: center; gap: 8px;
+}
+.theme-menu button:hover { background: var(--muted); }
+.theme-menu button[aria-checked="true"]::before { content: "\2713"; color: var(--primary); }
+.theme-menu button[aria-checked="false"]::before { content: ""; width: 9px; display: inline-block; }
+
+/* toast */
+.toast {
+  position: fixed; bottom: 22px; left: 50%; transform: translateX(-50%);
+  background: var(--card); color: var(--foreground); border: 1px solid var(--ring);
+  padding: 9px 16px; font-size: 12px; opacity: 0; transition: opacity .2s ease; pointer-events: none;
+}
+.toast.show { opacity: 1; }
+</style>
+</head>
+<body>
+  <!-- ============ Controls ============ -->
+  <aside class="controls">
+    <h1>Workspace panel — git-tree tryout</h1>
+    <p class="sub">Live prototype on the app's real tokens. Switch the rendering, switch the theme, and click everything.</p>
+
+    <div class="group">
+      <div class="lbl">Git-tree rendering</div>
+      <div class="segmented" id="tree-options">
+        <button data-tree="A" aria-pressed="true">
+          <span class="opt-name">A · Hairline elbows <span class="recommend">(rec.)</span></span>
+          <span class="opt-desc">1px CSS lines, square corners. Crisp, reflows with row height, matches the screenshot + square design system.</span>
+        </button>
+        <button data-tree="B" aria-pressed="false">
+          <span class="opt-name">B · Box-drawing glyphs</span>
+          <span class="opt-desc">Real ├─ └─ terminal characters on the rail. Heaviest "TUI" texture, font-dependent.</span>
+        </button>
+        <button data-tree="C" aria-pressed="false">
+          <span class="opt-name">C · Indent guide only</span>
+          <span class="opt-desc">Bare vertical guide, no elbow (VS Code style). Lightest, but loses the "connects to item" read.</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="group">
+      <div class="lbl">Theme</div>
+      <div class="segmented row" id="theme-options">
+        <button data-theme-set="dark" aria-pressed="true">Dark</button>
+        <button data-theme-set="light" aria-pressed="false">Light</button>
+        <button data-theme-set="warm" aria-pressed="false">Warm</button>
+        <button data-theme-set="tui" aria-pressed="false">TUI</button>
+      </div>
+    </div>
+
+    <div class="group">
+      <div class="lbl">Try the interactions</div>
+      <p class="hint">
+        • Click a <b>repo header / ▾</b> to collapse (persists)<br>
+        • Click a <b>worktree</b> to select (moves the box + ✕)<br>
+        • <b>✕</b> on the active row closes that worktree<br>
+        • <b>+ New worktree</b> grows the tree (watch the rail recompute the └─ )<br>
+        • <b>palette</b> icon (bottom-right) = theme switcher menu<br>
+        • <b>◧</b> top-right collapses the whole panel (icons center, no borders)
+      </p>
+      <button class="reset" id="reset">↻ Reset demo</button>
+    </div>
+    <p class="hint">Note: provider stays a <b>filled pill</b> ("claude"), per your call — the screenshot's dot-style provider is intentionally not used.</p>
+  </aside>
+
+  <!-- ============ The panel ============ -->
+  <section class="panel" id="panel" data-tree="A">
+    <header class="panel__header">
+      <span class="panel__title">Workspace</span>
+      <button class="iconbtn" id="panel-collapse" title="Collapse panel">&#9703;</button>
+    </header>
+
+    <div class="mini" id="mini"></div>
+
+    <div class="panel__body" id="tree"></div>
+
+    <footer class="panel__footer">
+      <button class="btn-load panel__footer-text" id="load">Load workspace</button>
+      <div class="gear-wrap">
+        <button class="gear" id="gear" title="Switch theme">
+          <svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 3a9 9 0 1 0 0 18c1.3 0 1.8-1 1.4-1.9-.4-.9.2-1.9 1.2-1.9H17a4 4 0 0 0 4-4c0-4.4-4-7.2-9-7.2Z"/>
+            <circle cx="7.5" cy="11" r="1.1"/><circle cx="9.8" cy="7" r="1.1"/><circle cx="14.4" cy="7" r="1.1"/>
+          </svg>
+        </button>
+        <div class="theme-menu" id="theme-menu">
+          <button data-theme-set="dark"  aria-checked="true">Dark</button>
+          <button data-theme-set="light" aria-checked="false">Light</button>
+          <button data-theme-set="warm"  aria-checked="false">Warm</button>
+          <button data-theme-set="tui"   aria-checked="false">TUI</button>
+        </div>
+      </div>
+    </footer>
+  </section>
+
+  <div class="toast" id="toast"></div>
+
+<script>
+// ---------------- Icons (inline SVG, monochrome via currentColor) ----------------
+// git-branch glyph for the repo header + collapsed rail (replaces the diamond).
+// In the real app this maps to a Nerd Font git-branch codepoint in the Icon registry.
+const GIT_SVG =
+  '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">' +
+  '<circle cx="6" cy="6" r="2.1"/><circle cx="6" cy="18" r="2.1"/><circle cx="18" cy="8" r="2.1"/>' +
+  '<path d="M6 8.1v7.8"/><path d="M18 10.1c0 3.2-3.4 3.4-6 4.4"/></svg>';
+
+// ---------------- Initial data model ----------------
+function seed() {
+  return [
+    {
+      name: "AI-14ALL", loaded: true, collapsed: false,
+      worktrees: [
+        { id: "a1", branch: "master", path: "tui-polish-1", provider: "claude", state: "active", stateLabel: "CL active", selected: true },
+        { id: "a2", branch: "product-document", path: "main", provider: "claude", state: "idle", stateLabel: "stale" },
+      ],
+    },
+    {
+      name: "CAPSTONE-IELTS", loaded: false, collapsed: false,
+      worktrees: [
+        { id: "c1", branch: "master", path: "main" },
+        { id: "c2", branch: "product-document", path: "main" },
+      ],
+    },
+  ];
+}
+let repos = seed();
+let newCount = 0;
+
+const panel = document.getElementById("panel");
+const treeEl = document.getElementById("tree");
+const miniEl = document.getElementById("mini");
+
+// ---------------- Persistence (collapsed state) ----------------
+const STORE = "ws-proto-collapsed";
+function loadCollapsed() {
+  try { return JSON.parse(localStorage.getItem(STORE) || "{}"); } catch { return {}; }
+}
+function saveCollapsed() {
+  const map = {};
+  repos.forEach(r => map[r.name] = r.collapsed);
+  localStorage.setItem(STORE, JSON.stringify(map));
+}
+(function applyStored(){ const m = loadCollapsed(); repos.forEach(r => { if (r.name in m) r.collapsed = m[r.name]; }); })();
+
+// ---------------- Render ----------------
+function el(tag, cls, html) { const e = document.createElement(tag); if (cls) e.className = cls; if (html != null) e.innerHTML = html; return e; }
+
+function render() {
+  treeEl.innerHTML = "";
+  repos.forEach((repo, ri) => {
+    const group = el("div", "ws-repo");
+    group.dataset.collapsed = repo.collapsed;
+
+    const header = el("button", "ws-repo__header");
+    header.innerHTML =
+      '<span class="ws-repo__chevron">&#9662;</span>' +
+      '<span class="ws-repo__icon">' + GIT_SVG + '</span>' +
+      '<span class="ws-repo__name">' + repo.name + '</span>' +
+      '<span class="ws-repo__close" title="Remove workspace" role="button" tabindex="0">&#10005;</span>';
+    header.addEventListener("click", () => { repo.collapsed = !repo.collapsed; saveCollapsed(); render(); });
+    header.querySelector(".ws-repo__close").addEventListener("click", (e) => { e.stopPropagation(); removeRepo(repo); });
+    group.appendChild(header);
+
+    const children = el("div", "ws-repo__children");
+    repo.worktrees.forEach(wt => children.appendChild(renderWorktree(repo, wt)));
+    if (repo.loaded) {
+      const node = el("div", "ws-node");
+      const btn = el("button", "ws-newtree", "+ New worktree");
+      btn.addEventListener("click", () => addWorktree(repo));
+      node.appendChild(btn);
+      children.appendChild(node);
+    }
+    group.appendChild(children);
+    treeEl.appendChild(group);
+
+    if (ri < repos.length - 1) treeEl.appendChild(el("div", "ws-sep"));
+  });
+  renderMini();
+}
+
+function renderWorktree(repo, wt) {
+  const node = el("div", "ws-node");
+  const row = el("button", "ws-worktree");
+  if (wt.selected) row.dataset.selected = "true";
+
+  const top = el("div", "ws-worktree__top");
+  top.appendChild(el("span", "ws-worktree__branch", wt.branch));
+  const close = el("button", "ws-worktree__close", "&#10005;");
+  close.title = "Close worktree";
+  close.addEventListener("click", (e) => { e.stopPropagation(); closeWorktree(repo, wt); });
+  top.appendChild(close);
+  row.appendChild(top);
+
+  row.appendChild(el("div", "ws-worktree__path", wt.path));
+
+  if (wt.provider || wt.state) {
+    const chips = el("div", "ws-worktree__chips");
+    if (wt.provider) {
+      const p = el("span", "chip-provider", wt.provider);
+      p.dataset.provider = wt.provider;
+      chips.appendChild(p);
+    }
+    if (wt.state) {
+      const s = el("span", "chip-state");
+      const d = el("span", "dot"); d.dataset.state = wt.state;
+      s.appendChild(d); s.appendChild(document.createTextNode(wt.stateLabel || wt.state));
+      chips.appendChild(s);
+    }
+    row.appendChild(chips);
+  }
+
+  row.addEventListener("click", () => selectWorktree(wt));
+  node.appendChild(row);
+  return node;
+}
+
+function renderMini() {
+  miniEl.innerHTML = "";
+  repos.forEach(r => {
+    const b = el("div", "badge", GIT_SVG + '<span class="mini-initial">' + r.name[0] + '</span>');
+    b.title = r.name;
+    b.addEventListener("click", () => { panel.classList.remove("collapsed"); });
+    miniEl.appendChild(b);
+  });
+}
+
+// ---------------- Interactions ----------------
+function selectWorktree(wt) {
+  repos.forEach(r => r.worktrees.forEach(w => w.selected = false));
+  wt.selected = true;
+  render();
+}
+function removeRepo(repo) {
+  repos = repos.filter(r => r !== repo);
+  toast("Removed workspace: " + repo.name);
+  render();
+}
+function closeWorktree(repo, wt) {
+  repo.worktrees = repo.worktrees.filter(w => w.id !== wt.id);
+  toast("Closed worktree: " + wt.branch);
+  render();
+}
+function addWorktree(repo) {
+  newCount++;
+  repo.worktrees.push({ id: "n" + newCount, branch: "feature/new-" + newCount, path: "main" });
+  toast("New worktree added (real app opens the create dialog)");
+  render();
+}
+
+// theme
+function setTheme(name) {
+  document.documentElement.setAttribute("data-theme", name);
+  document.querySelectorAll("#theme-options button").forEach(b => b.setAttribute("aria-pressed", b.dataset.themeSet === name));
+  document.querySelectorAll("#theme-menu button").forEach(b => b.setAttribute("aria-checked", b.dataset.themeSet === name));
+}
+function setTree(opt) {
+  panel.dataset.tree = opt;
+  document.querySelectorAll("#tree-options button").forEach(b => b.setAttribute("aria-pressed", b.dataset.tree === opt));
+}
+
+document.getElementById("tree-options").addEventListener("click", e => {
+  const b = e.target.closest("button"); if (b) setTree(b.dataset.tree);
+});
+document.getElementById("theme-options").addEventListener("click", e => {
+  const b = e.target.closest("button"); if (b) setTheme(b.dataset.themeSet);
+});
+
+const gear = document.getElementById("gear");
+const themeMenu = document.getElementById("theme-menu");
+gear.addEventListener("click", e => {
+  e.stopPropagation();
+  gear.classList.remove("spin"); void gear.offsetWidth; gear.classList.add("spin");
+  themeMenu.classList.toggle("open");
+});
+themeMenu.addEventListener("click", e => {
+  const b = e.target.closest("button");
+  if (b) { setTheme(b.dataset.themeSet); themeMenu.classList.remove("open"); }
+});
+document.addEventListener("click", () => themeMenu.classList.remove("open"));
+
+document.getElementById("panel-collapse").addEventListener("click", () => panel.classList.toggle("collapsed"));
+document.getElementById("load").addEventListener("click", () => toast("Load workspace dialog would open"));
+document.getElementById("reset").addEventListener("click", () => { repos = seed(); newCount = 0; localStorage.removeItem(STORE); render(); toast("Demo reset"); });
+
+let toastTimer;
+function toast(msg) {
+  const t = document.getElementById("toast");
+  t.textContent = msg; t.classList.add("show");
+  clearTimeout(toastTimer); toastTimer = setTimeout(() => t.classList.remove("show"), 1800);
+}
+
+render();
+</script>
+</body>
+</html>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1732,7 +1732,7 @@ export function App() {
 					data-testid="shell-layout"
 					style={{
 						gridTemplateColumns: `${
-							sidebarCollapsed ? 100 : sidebarWidth
+							sidebarCollapsed ? 88 : sidebarWidth
 						}px minmax(0, 1fr)`,
 					}}
 				>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1732,7 +1732,7 @@ export function App() {
 					data-testid="shell-layout"
 					style={{
 						gridTemplateColumns: `${
-							sidebarCollapsed ? 68 : sidebarWidth
+							sidebarCollapsed ? 100 : sidebarWidth
 						}px minmax(0, 1fr)`,
 					}}
 				>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -11,6 +11,7 @@ import { RepositoryInput } from "../features/repository/RepositoryInput";
 import { RestorePrompt } from "../features/repository/RestorePrompt";
 import { type SessionSidebarWorkspace } from "../features/workspace/components/SessionSidebar";
 import { sortSidebarWorkspaces } from "../features/workspace/logic/sort-sidebar-workspaces";
+import { useCollapsedWorkspaces } from "../features/workspace/logic/use-collapsed-workspaces";
 import { workspaceReducer } from "../features/workspace/logic/workspace-state";
 import { PresetManager } from "../features/terminals/components/PresetManager";
 import {
@@ -129,7 +130,7 @@ type StartupMode = "loading" | "prompt" | "ready";
 const NOOP = () => {};
 
 export function App() {
-	const { resolvedTheme, palette } = useTheme();
+	const { resolvedTheme, palette, setTheme } = useTheme();
 	const terminalTheme = useMemo(() => terminalThemeFor(palette), [palette]);
 	const appPlatform = useMemo(detectPlatform, []);
 	const {
@@ -152,6 +153,10 @@ export function App() {
 	}
 
 	const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+	const {
+		collapsedIds: collapsedWorkspaceIds,
+		toggle: toggleWorkspaceCollapsed,
+	} = useCollapsedWorkspaces();
 	const [pendingRename, setPendingRename] = useState<{
 		workspaceId: string;
 		worktreeId: string;
@@ -1753,6 +1758,10 @@ export function App() {
 							setWorkflowDetailTarget({ workspaceId, worktreeId })
 						}
 						dispatch={dispatch}
+						collapsedWorkspaceIds={collapsedWorkspaceIds}
+						onToggleWorkspaceCollapsed={toggleWorkspaceCollapsed}
+						palette={palette}
+						onSetTheme={setTheme}
 					/>
 
 					<section className="shell-main-column" ref={mainColRef}>

--- a/src/app/components/SidebarPanel.tsx
+++ b/src/app/components/SidebarPanel.tsx
@@ -37,6 +37,10 @@ type Props = {
 					clearedAt: number;
 			  },
 	) => void;
+	collapsedWorkspaceIds: string[];
+	onToggleWorkspaceCollapsed: (workspaceId: string) => void;
+	palette: "light" | "dark" | "warm" | "tui";
+	onSetTheme: (mode: "light" | "dark" | "warm" | "tui") => void;
 };
 
 /**
@@ -61,6 +65,10 @@ export function SidebarPanel(props: Props): React.ReactElement {
 		handleRemoveWorkspace,
 		onOpenWorkflowDetail,
 		dispatch,
+		collapsedWorkspaceIds,
+		onToggleWorkspaceCollapsed,
+		palette,
+		onSetTheme,
 	} = props;
 
 	return (
@@ -118,6 +126,10 @@ export function SidebarPanel(props: Props): React.ReactElement {
 				}}
 				onOpenWorkflowDetail={onOpenWorkflowDetail}
 				pendingRename={pendingRename}
+				collapsedWorkspaceIds={collapsedWorkspaceIds}
+				onToggleWorkspaceCollapsed={onToggleWorkspaceCollapsed}
+				palette={palette}
+				onSetTheme={onSetTheme}
 			/>
 		</div>
 	);

--- a/src/app/components/SidebarPanel.tsx
+++ b/src/app/components/SidebarPanel.tsx
@@ -2,6 +2,7 @@ import {
 	SessionSidebar,
 	type SessionSidebarWorkspace,
 } from "../../features/workspace/components/SessionSidebar";
+import type { Palette } from "../../lib/use-theme";
 
 type PendingRename = {
 	workspaceId: string;
@@ -39,8 +40,8 @@ type Props = {
 	) => void;
 	collapsedWorkspaceIds: string[];
 	onToggleWorkspaceCollapsed: (workspaceId: string) => void;
-	palette: "light" | "dark" | "warm" | "tui";
-	onSetTheme: (mode: "light" | "dark" | "warm" | "tui") => void;
+	palette: Palette;
+	onSetTheme: (mode: Palette) => void;
 };
 
 /**

--- a/src/app/hooks/use-pane-resizers.ts
+++ b/src/app/hooks/use-pane-resizers.ts
@@ -3,7 +3,9 @@ import type { MouseEvent as ReactMouseEvent } from "react";
 
 const REVIEW_RAIL_MIN = 240;
 const REVIEW_RAIL_MAX = 520;
-const SIDEBAR_MIN = 180;
+// Below ~200px the worktree list overhangs and footer icons (palette/close/
+// collapse) clip — QA-measured clean floor (docs/design-specs workspace rework).
+const SIDEBAR_MIN = 200;
 const SIDEBAR_MAX = 480;
 
 type Dimensions = {

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -612,11 +612,12 @@ select {
    (was the wide row card). Box uses --primary (high-contrast in every theme;
    --accent is a near-invisible dark step in tui); the initial stays foreground
    so it's always legible and centered in the 24px cell. */
-/* Kill the wide row card border on the selected row in collapsed — needs the
-   [data-selected] qualifier to outrank tui.css's selected-row border (else tui
-   shows a double box: the wide row border + the tight item box). */
+/* Kill the wide row card border on the selected row in collapsed so only the
+   tight item box shows. The [data-attention] qualifier is required to outrank
+   tui.css's `[data-selected][data-attention]` selected-row border (0,4,0) — the
+   row always has data-attention, so this (0,5,0) rule wins without !important. */
 .shell-sidebar[data-collapsed="true"]
-	.shell-sidebar__row[data-selected="true"] {
+	.shell-sidebar__row[data-selected="true"][data-attention] {
 	border-color: transparent;
 	background: transparent;
 }

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -1199,9 +1199,13 @@ select {
 	padding-left: 4px;
 }
 
-/* collapsed badge: git icon + initial, left-aligned (the rail descends under it) */
+/* collapsed badge: git icon + initial in a ROW (base badge is inline-grid, which
+   ignored flex-direction and stacked them — switch to flex so the initial sits to
+   the right of the git icon). Left-aligned so the rail descends under the icon. */
 .shell-sidebar[data-collapsed="true"] .shell-sidebar__workspace-badge {
+	display: flex;
 	flex-direction: row;
+	align-items: center;
 	gap: var(--space-1);
 	width: auto;
 	height: auto;

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -596,23 +596,31 @@ select {
 }
 
 .shell-sidebar[data-collapsed="true"] .shell-sidebar__item {
-	/* Leaf marker (single initial) sitting on the rail, not a 40px box. */
-	width: auto;
+	/* Small centered cell for the single-initial marker on the rail (so the
+	   selected box is tight and the initial sits centered inside it). */
+	width: 24px;
+	height: 24px;
 	min-height: unset;
-	padding: 2px 0;
-	justify-content: flex-start;
+	padding: 0;
+	justify-content: center;
 }
 .shell-sidebar[data-collapsed="true"] .shell-sidebar__marker {
-	width: auto;
-	height: auto;
+	width: 100%;
+	height: 100%;
 }
-/* highlight the active worktree's marker (no card box in collapsed). Use
-   --primary (the cursor/accent colour, high-contrast in every theme) — the
-   --accent token is a low-contrast dark step in tui, so the initial vanished. */
+/* Selected worktree in collapsed: a TIGHT centered box around the initial cell
+   (was the wide row card). Box uses --primary (high-contrast in every theme;
+   --accent is a near-invisible dark step in tui); the initial stays foreground
+   so it's always legible and centered in the 24px cell. */
+.shell-sidebar[data-collapsed="true"]
+	.shell-sidebar__row[data-selected="true"]
+	.shell-sidebar__item {
+	border: var(--shell-border-width) solid var(--primary);
+}
 .shell-sidebar[data-collapsed="true"]
 	.shell-sidebar__row[data-selected="true"]
 	.shell-sidebar__marker {
-	color: var(--primary);
+	color: var(--text-primary);
 	font-weight: 700;
 }
 

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -566,7 +566,32 @@ select {
 }
 
 .shell-sidebar[data-collapsed="true"] .shell-sidebar__list {
-	justify-items: center;
+	align-items: center;
+}
+
+/* Collapsed: flatten the worktree tree — no rail gutter, no connector pseudos,
+   no card boxes; just centered marker glyphs. (The collapsed CSS predated the
+   .shell-sidebar__node tree restructure, which is why the rail leaked through.) */
+.shell-sidebar[data-collapsed="true"] .shell-sidebar__workspace-items {
+	align-items: center;
+}
+.shell-sidebar[data-collapsed="true"] .shell-sidebar__node {
+	padding-left: 0;
+	padding-bottom: var(--space-1);
+}
+.shell-sidebar[data-collapsed="true"] .shell-sidebar__node::before,
+.shell-sidebar[data-collapsed="true"] .shell-sidebar__node::after {
+	display: none;
+}
+.shell-sidebar[data-collapsed="true"] .shell-sidebar__row {
+	background: transparent;
+	border-color: transparent;
+	padding: 0;
+}
+.shell-sidebar[data-collapsed="true"] .shell-sidebar__node--new button {
+	width: 40px;
+	min-width: 0;
+	padding: 0;
 }
 
 .shell-sidebar[data-collapsed="true"] .shell-sidebar__item {

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -489,7 +489,7 @@ select {
  * session-info pane's .shell-label eyebrows are unaffected. */
 .shell-sidebar__header .shell-label {
 	font-size: var(--ws-fs-header);
-	font-weight: 500;
+	font-weight: 700;
 	letter-spacing: 0.12em;
 	text-align: left;
 }
@@ -531,6 +531,9 @@ select {
 	height: 100%;
 	min-height: 0;
 	min-width: 0;
+	/* Clip the full-bleed header's negative-margin so the top separator can't
+	   protrude past the panel edge when the sidebar is shrunk. */
+	overflow-x: clip;
 	border-color: var(--pane-border-sessions);
 }
 
@@ -669,6 +672,10 @@ select {
 	/* Left-aligned like the prototype (a raw <button> defaults to center, which
 	   centered wrapped titles when the panel is narrow). */
 	text-align: left;
+	/* Truncate (not wrap) when the panel is shrunk down. */
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 	color: var(--text-secondary);
 	background: transparent;
 	border: none;
@@ -751,7 +758,6 @@ select {
 	padding: 0 var(--space-1) var(--space-1);
 	color: var(--text-muted);
 	font-size: 11px;
-	font-style: italic;
 	line-height: 1.4;
 }
 

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -546,12 +546,8 @@ select {
 	align-items: center;
 	justify-content: space-between;
 	gap: var(--space-2);
-	/* Full-bleed separator (matches prototype): cancel the sidebar's --space-3
-	   inset so the border-bottom spans edge to edge, keep content in place. */
-	margin-inline: calc(-1 * var(--space-3));
-	padding-inline: var(--space-3);
-	padding-bottom: var(--space-2);
-	border-bottom: var(--shell-border-width) solid var(--panel-border);
+	/* No separator line — components are separated by whitespace (the list's
+	   top margin gives the gap below this header). */
 }
 
 .shell-sidebar[data-collapsed="true"] {
@@ -560,11 +556,8 @@ select {
 }
 
 .shell-sidebar[data-collapsed="true"] .shell-sidebar__header {
-	/* Center the collapse toggle in the narrow rail (flex-end pinned it to the
-	   right wall, 13px off-center). */
+	/* Center the collapse toggle in the narrow rail. */
 	justify-content: center;
-	margin-inline: calc(-1 * var(--space-3));
-	padding-inline: var(--space-3);
 }
 
 .shell-sidebar[data-collapsed="true"] .shell-sidebar__list {
@@ -646,10 +639,10 @@ select {
 	flex-direction: column;
 	min-height: 0;
 	overflow-y: auto;
-	/* No top margin: the first group's padding-top already gives the 12px below
-	   the WORKSPACE separator (prototype tightness — was doubling to 24px). */
-	margin-top: 0;
-	gap: 0;
+	/* Even whitespace separates components (no lines): same gap below the header
+	   and between workspace groups. */
+	margin-top: var(--space-4);
+	gap: var(--space-4);
 	padding-right: 2px;
 }
 
@@ -661,22 +654,15 @@ select {
 .shell-sidebar__workspace-group {
 	display: flex;
 	flex-direction: column;
-	/* Header -> first card gap; tightened to the prototype (~10px). */
+	/* Header -> first card gap (internal to the group). */
 	gap: var(--space-1);
-	/* Asymmetric vertical padding: button sits close to the divider below,
-	 * with more breathing room from the worktree cards above. */
-	padding: var(--space-3) 0 var(--space-1);
+	/* No own vertical padding — the list's row gap handles even spacing between
+	   groups now that the divider is gone. */
+	padding: 0;
 }
 
-.shell-sidebar__workspace-group + .shell-sidebar__workspace-group::before {
-	content: "";
-	display: block;
-	height: 1px;
-	margin: 0 var(--space-2) var(--space-2);
-	/* A single uniform stroke — same thickness/presence from start to end.
-	 * (Was a center-weighted gradient that faded to transparent at both ends.) */
-	background: var(--panel-border);
-}
+/* No divider line between workspaces — the list's row gap separates them with
+   even whitespace instead. */
 
 .shell-sidebar__workspace-header {
 	display: flex;
@@ -1211,7 +1197,7 @@ select {
 
 .shell-sidebar[data-collapsed="true"] .shell-sidebar__workspace-group {
 	align-items: stretch;
-	padding: var(--space-3) 0 var(--space-1);
+	padding: 0;
 	background: transparent;
 	border: none;
 }

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -619,7 +619,9 @@ select {
 .shell-sidebar__workspace-header {
 	display: flex;
 	align-items: center;
-	gap: var(--space-2);
+	/* Tighter icon↔name gap so the repo title lines up with the worktree titles
+	   below it (was --space-2, which pushed the title ~6px past the row titles). */
+	gap: var(--space-1);
 	padding-left: 4px; /* chevron box (12px, centered) -> center at x=10 = rail x */
 }
 

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -1129,6 +1129,18 @@ select {
 	flex: 0 0 auto;
 }
 
+/* Legible hover for the sidebar's shadcn ghost/outline buttons. The legacy
+   bridge maps --accent -> --primary, so the default `hover:bg-accent` +
+   `hover:text-accent-foreground` washes text out. Use a muted step + primary
+   text instead (good contrast in every theme; selected-row accent untouched). */
+.shell-sidebar__header button:hover,
+.shell-sidebar__workspace-remove:hover,
+.shell-sidebar__node--new button:hover,
+.shell-sidebar__footer--global button:hover {
+	background-color: var(--muted);
+	color: var(--text-primary);
+}
+
 .shell-sidebar[data-collapsed="true"] .shell-sidebar__workspace-group {
 	align-items: center;
 	padding: 0;

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -612,6 +612,14 @@ select {
    (was the wide row card). Box uses --primary (high-contrast in every theme;
    --accent is a near-invisible dark step in tui); the initial stays foreground
    so it's always legible and centered in the 24px cell. */
+/* Kill the wide row card border on the selected row in collapsed — needs the
+   [data-selected] qualifier to outrank tui.css's selected-row border (else tui
+   shows a double box: the wide row border + the tight item box). */
+.shell-sidebar[data-collapsed="true"]
+	.shell-sidebar__row[data-selected="true"] {
+	border-color: transparent;
+	background: transparent;
+}
 .shell-sidebar[data-collapsed="true"]
 	.shell-sidebar__row[data-selected="true"]
 	.shell-sidebar__item {

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -546,8 +546,12 @@ select {
 	align-items: center;
 	justify-content: space-between;
 	gap: var(--space-2);
-	/* No separator line — components are separated by whitespace (the list's
-	   top margin gives the gap below this header). */
+	/* Full-bleed separator (matches prototype): cancel the sidebar's --space-3
+	   inset so the border-bottom spans edge to edge, keep content in place. */
+	margin-inline: calc(-1 * var(--space-3));
+	padding-inline: var(--space-3);
+	padding-bottom: var(--space-2);
+	border-bottom: var(--shell-border-width) solid var(--panel-border);
 }
 
 .shell-sidebar[data-collapsed="true"] {
@@ -556,8 +560,11 @@ select {
 }
 
 .shell-sidebar[data-collapsed="true"] .shell-sidebar__header {
-	/* Center the collapse toggle in the narrow rail. */
+	/* Center the collapse toggle in the narrow rail (flex-end pinned it to the
+	   right wall, 13px off-center). */
 	justify-content: center;
+	margin-inline: calc(-1 * var(--space-3));
+	padding-inline: var(--space-3);
 }
 
 .shell-sidebar[data-collapsed="true"] .shell-sidebar__list {
@@ -639,10 +646,10 @@ select {
 	flex-direction: column;
 	min-height: 0;
 	overflow-y: auto;
-	/* Even whitespace separates components (no lines): same gap below the header
-	   and between workspace groups. */
-	margin-top: var(--space-4);
-	gap: var(--space-4);
+	/* No top margin: the first group's padding-top already gives the 12px below
+	   the WORKSPACE separator (prototype tightness — was doubling to 24px). */
+	margin-top: 0;
+	gap: 0;
 	padding-right: 2px;
 }
 
@@ -654,15 +661,22 @@ select {
 .shell-sidebar__workspace-group {
 	display: flex;
 	flex-direction: column;
-	/* Header -> first card gap (internal to the group). */
+	/* Header -> first card gap; tightened to the prototype (~10px). */
 	gap: var(--space-1);
-	/* No own vertical padding — the list's row gap handles even spacing between
-	   groups now that the divider is gone. */
-	padding: 0;
+	/* Asymmetric vertical padding: button sits close to the divider below,
+	 * with more breathing room from the worktree cards above. */
+	padding: var(--space-3) 0 var(--space-1);
 }
 
-/* No divider line between workspaces — the list's row gap separates them with
-   even whitespace instead. */
+.shell-sidebar__workspace-group + .shell-sidebar__workspace-group::before {
+	content: "";
+	display: block;
+	height: 1px;
+	margin: 0 var(--space-2) var(--space-2);
+	/* A single uniform stroke — same thickness/presence from start to end.
+	 * (Was a center-weighted gradient that faded to transparent at both ends.) */
+	background: var(--panel-border);
+}
 
 .shell-sidebar__workspace-header {
 	display: flex;
@@ -1197,7 +1211,7 @@ select {
 
 .shell-sidebar[data-collapsed="true"] .shell-sidebar__workspace-group {
 	align-items: stretch;
-	padding: 0;
+	padding: var(--space-3) 0 var(--space-1);
 	background: transparent;
 	border: none;
 }

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -1197,16 +1197,14 @@ select {
 	flex: 0 0 auto;
 }
 
-/* Legible hover for the sidebar's shadcn ghost/outline buttons. The legacy
-   bridge maps --accent -> --primary, so the default `hover:bg-accent` +
-   `hover:text-accent-foreground` washes text out. Use a muted step + primary
-   text instead (good contrast in every theme; selected-row accent untouched). */
+/* Sidebar button hover: highlight the icon/label itself (accent colour) with NO
+   background fill. (Overrides shadcn's `hover:bg-accent` + text wash.) */
 .shell-sidebar__header button:hover,
 .shell-sidebar__workspace-remove:hover,
 .shell-sidebar__node--new button:hover,
 .shell-sidebar__footer--global button:hover {
-	background-color: var(--muted);
-	color: var(--text-primary);
+	background-color: transparent;
+	color: var(--primary);
 }
 
 .shell-sidebar[data-collapsed="true"] .shell-sidebar__workspace-group {

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -488,7 +488,7 @@ select {
  * muted, left-aligned section eyebrow. Scoped to the sidebar header so the
  * session-info pane's .shell-label eyebrows are unaffected. */
 .shell-sidebar__header .shell-label {
-	font-size: 11px;
+	font-size: var(--ws-fs-header);
 	font-weight: 500;
 	letter-spacing: 0.12em;
 	text-align: left;
@@ -612,14 +612,49 @@ select {
 .shell-sidebar__workspace-header {
 	display: flex;
 	align-items: center;
-	justify-content: space-between;
 	gap: var(--space-2);
+	padding-left: 4px; /* chevron box (12px, centered) -> center at x=10 = rail x */
+}
+
+.shell-sidebar__workspace-toggle {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	padding: 0;
+	background: transparent;
+	border: none;
+	color: var(--text-secondary);
+	cursor: pointer;
+}
+
+.shell-sidebar__chevron {
+	width: 12px;
+	text-align: center;
+	font-size: 11px;
+}
+
+.shell-sidebar__workspace-icon {
+	display: inline-flex;
+	align-items: center;
+	font-size: 13px;
+}
+
+.shell-sidebar__workspace-remove {
+	margin-left: auto;
+	opacity: 0;
+	transition: opacity 0.12s ease;
+}
+
+.shell-sidebar__workspace-header:hover .shell-sidebar__workspace-remove,
+.shell-sidebar__workspace-header:focus-within .shell-sidebar__workspace-remove {
+	opacity: 1;
 }
 
 .shell-sidebar__workspace-name {
 	min-width: 0;
 	padding: 0;
-	font-size: var(--font-size-label);
+	font-size: var(--ws-fs-repo);
+	font-weight: 700;
 	letter-spacing: 0.04em;
 	text-transform: uppercase;
 	color: var(--text-secondary);
@@ -660,7 +695,44 @@ select {
 .shell-sidebar__workspace-items {
 	display: flex;
 	flex-direction: column;
-	gap: 8px;
+	gap: 0; /* spacing moves into node padding so the trunk stays continuous */
+}
+
+.shell-sidebar__node {
+	position: relative;
+	padding-left: 24px;
+	padding-bottom: 8px;
+}
+
+.shell-sidebar__node:last-child {
+	padding-bottom: 0;
+}
+
+.shell-sidebar__node::before {
+	/* vertical trunk: 2px solid, centered on chevron (x=10) */
+	content: "";
+	position: absolute;
+	left: 9px;
+	top: 0;
+	bottom: 0;
+	border-left: 2px solid var(--rail);
+}
+
+.shell-sidebar__node:last-child::before {
+	/* stop at the elbow -> └─ */
+	bottom: auto;
+	height: 18px;
+}
+
+.shell-sidebar__node::after {
+	/* horizontal elbow aligned to the title line */
+	content: "";
+	position: absolute;
+	left: 9px;
+	top: 17px;
+	width: 13px;
+	height: 2px;
+	background: var(--rail);
 }
 
 .shell-sidebar__workspace-empty {
@@ -678,8 +750,8 @@ select {
  * and a11y, but visual styling lives here.
  */
 .shell-sidebar__row {
-	background: var(--panel-bg);
-	border: var(--shell-border-width) solid var(--panel-border);
+	background: transparent;
+	border: var(--shell-border-width) solid transparent; /* reserve space; invisible until selected */
 	border-radius: var(--radius-sm);
 	overflow: hidden;
 	cursor: pointer;
@@ -706,9 +778,9 @@ select {
 }
 
 /* Session title: MIDDLE tier of the hierarchy — below the workspace name
- * (17px/700), above the global eyebrow (11px/500). */
+ * (repo/700), above the global eyebrow (header/500). */
 .shell-sidebar__item strong {
-	font-size: 14px;
+	font-size: var(--ws-fs-branch);
 	font-weight: 600;
 }
 
@@ -917,6 +989,10 @@ select {
 	color: var(--text-secondary);
 }
 
+.shell-sidebar__branch {
+	font-size: var(--ws-fs-path);
+}
+
 .shell-sidebar__processes {
 	display: flex;
 	flex-direction: column;
@@ -930,7 +1006,7 @@ select {
 	gap: var(--space-1);
 	/* Match the card task line so all summary text is one size (see
 	 * .shell-sidebar__card-task); labels and context inherit this. */
-	font-size: 0.7rem;
+	font-size: var(--ws-fs-chip);
 	min-width: 0;
 }
 
@@ -1008,7 +1084,19 @@ select {
 
 .shell-sidebar__process--overflow {
 	color: var(--text-muted);
-	font-size: 0.7rem;
+	font-size: var(--ws-fs-chip);
+}
+
+/* Type ladder: explicit chip size on process sub-elements and CTAs (spec §5) */
+.shell-sidebar__process-context,
+.shell-sidebar__process-label {
+	font-size: var(--ws-fs-chip);
+}
+
+/* CTAs (+ New session / Load workspace) match the branch title size (spec D9) */
+.shell-sidebar__node--new .w-full,
+.shell-sidebar__footer--global .w-full {
+	font-size: var(--ws-fs-branch);
 }
 
 .shell-sidebar[data-collapsed="true"] .shell-sidebar__workspace-group {
@@ -1019,6 +1107,26 @@ select {
 }
 
 .shell-sidebar[data-collapsed="true"] .shell-sidebar__workspace-header {
+	justify-content: center;
+}
+
+/* collapsed badge: git icon + initial side-by-side, no pill background */
+.shell-sidebar[data-collapsed="true"] .shell-sidebar__workspace-badge {
+	flex-direction: row;
+	gap: 5px;
+	width: auto;
+	height: auto;
+	background: transparent;
+	border-radius: 0;
+}
+
+.shell-sidebar__workspace-badge-initial {
+	font-weight: 700;
+	font-size: 12px;
+}
+
+.shell-sidebar[data-collapsed="true"] .shell-sidebar__footer--global {
+	display: flex;
 	justify-content: center;
 }
 
@@ -3890,8 +3998,7 @@ select {
 	align-items: center;
 	padding: 1px 6px;
 	border-radius: var(--radius-sm);
-	/* Unified with the rest of the card summary text (.shell-sidebar__card-task). */
-	font-size: 0.7rem;
+	font-size: var(--ws-fs-chip);
 	font-weight: 600;
 	letter-spacing: 0.3px;
 	text-transform: lowercase;

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -1094,9 +1094,17 @@ select {
 }
 
 /* CTAs (+ New session / Load workspace) match the branch title size (spec D9) */
-.shell-sidebar__node--new .w-full,
-.shell-sidebar__footer--global .w-full {
+.shell-sidebar__node--new .w-full {
 	font-size: var(--ws-fs-branch);
+}
+.shell-sidebar__footer--global .w-full {
+	/* Load button shares the row with the theme trigger instead of forcing 100% */
+	flex: 1 1 auto;
+	width: auto;
+	font-size: var(--ws-fs-branch);
+}
+.shell-sidebar__theme-trigger {
+	flex: 0 0 auto;
 }
 
 .shell-sidebar[data-collapsed="true"] .shell-sidebar__workspace-group {
@@ -1126,8 +1134,11 @@ select {
 }
 
 .shell-sidebar[data-collapsed="true"] .shell-sidebar__footer--global {
-	display: flex;
-	justify-content: center;
+	flex-direction: column;
+	align-items: center;
+}
+.shell-sidebar[data-collapsed="true"] .shell-sidebar__footer--global .w-full {
+	flex: 0 0 auto;
 }
 
 /* ── Session chip bar ────────────────────────────────── */
@@ -2473,6 +2484,9 @@ select {
 
 .shell-sidebar__footer--global {
 	margin-top: var(--space-3);
+	display: flex;
+	gap: var(--space-2);
+	align-items: stretch;
 }
 
 .shell-error-banner {

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -1197,6 +1197,15 @@ select {
 	flex: 0 0 auto;
 }
 
+/* Chrome icon buttons recede at rest so the hover highlight reads in every
+   theme (a dim->accent shift; in dark --primary is a near-white that wouldn't
+   pop against full-foreground icons). */
+.shell-sidebar__header button,
+.shell-sidebar__theme-trigger,
+.shell-sidebar__workspace-remove {
+	color: var(--muted-foreground);
+}
+
 /* Sidebar button hover: highlight the icon/label itself (accent colour) with NO
    background fill. (Overrides shadcn's `hover:bg-accent` + text wash.) */
 .shell-sidebar__header button:hover,

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -605,7 +605,8 @@ select {
 .shell-sidebar__workspace-group {
 	display: flex;
 	flex-direction: column;
-	gap: var(--space-2);
+	/* Header -> first card gap; tightened to the prototype (~10px). */
+	gap: var(--space-1);
 	/* Asymmetric vertical padding: button sits close to the divider below,
 	 * with more breathing room from the worktree cards above. */
 	padding: var(--space-3) 0 var(--space-1);

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -560,7 +560,9 @@ select {
 }
 
 .shell-sidebar[data-collapsed="true"] .shell-sidebar__header {
-	justify-content: flex-end;
+	/* Center the collapse toggle in the narrow rail (flex-end pinned it to the
+	   right wall, 13px off-center). */
+	justify-content: center;
 	margin-inline: calc(-1 * var(--space-3));
 	padding-inline: var(--space-3);
 }

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -590,7 +590,9 @@ select {
 	flex-direction: column;
 	min-height: 0;
 	overflow-y: auto;
-	margin-top: var(--space-3);
+	/* No top margin: the first group's padding-top already gives the 12px below
+	   the WORKSPACE separator (prototype tightness — was doubling to 24px). */
+	margin-top: 0;
 	gap: 0;
 	padding-right: 2px;
 }
@@ -613,7 +615,7 @@ select {
 	content: "";
 	display: block;
 	height: 1px;
-	margin: 0 var(--space-2) var(--space-3);
+	margin: 0 var(--space-2) var(--space-2);
 	/* A single uniform stroke — same thickness/presence from start to end.
 	 * (Was a center-weighted gradient that faded to transparent at both ends.) */
 	background: var(--panel-border);
@@ -720,7 +722,8 @@ select {
 .shell-sidebar__node {
 	position: relative;
 	padding-left: 24px;
-	padding-bottom: 8px;
+	/* Gap between cards — matches the prototype's ~4px card spacing (was 8px). */
+	padding-bottom: var(--space-1);
 }
 
 .shell-sidebar__node:last-child {

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -630,7 +630,7 @@ select {
 .shell-sidebar__chevron {
 	width: 12px;
 	text-align: center;
-	font-size: 11px;
+	font-size: var(--ws-fs-header);
 }
 
 .shell-sidebar__workspace-icon {
@@ -1130,7 +1130,7 @@ select {
 
 .shell-sidebar__workspace-badge-initial {
 	font-weight: 700;
-	font-size: 12px;
+	font-size: var(--ws-fs-path);
 }
 
 .shell-sidebar[data-collapsed="true"] .shell-sidebar__footer--global {

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -543,6 +543,10 @@ select {
 	align-items: center;
 	justify-content: space-between;
 	gap: var(--space-2);
+	/* Full-bleed separator (matches prototype): cancel the sidebar's --space-3
+	   inset so the border-bottom spans edge to edge, keep content in place. */
+	margin-inline: calc(-1 * var(--space-3));
+	padding-inline: var(--space-3);
 	padding-bottom: var(--space-2);
 	border-bottom: var(--shell-border-width) solid var(--panel-border);
 }
@@ -657,6 +661,9 @@ select {
 	font-weight: 700;
 	letter-spacing: 0.04em;
 	text-transform: uppercase;
+	/* Left-aligned like the prototype (a raw <button> defaults to center, which
+	   centered wrapped titles when the panel is narrow). */
+	text-align: left;
 	color: var(--text-secondary);
 	background: transparent;
 	border: none;

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -557,6 +557,9 @@ select {
 
 .shell-sidebar[data-collapsed="true"] .shell-sidebar__header {
 	justify-content: center;
+	/* collapsed sidebar uses 8px inset, so match the full-bleed cancel to 8px */
+	margin-inline: -8px;
+	padding-inline: 8px;
 }
 
 .shell-sidebar[data-collapsed="true"] .shell-sidebar__list {
@@ -789,6 +792,13 @@ select {
 .shell-sidebar__item strong {
 	font-size: var(--ws-fs-branch);
 	font-weight: 600;
+	/* Truncate long titles cleanly at narrow widths (no spill) — same recipe
+	   as the process rows. align-self:stretch gives ellipsis a box to clip. */
+	align-self: stretch;
+	max-width: 100%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 /*
@@ -998,6 +1008,11 @@ select {
 
 .shell-sidebar__branch {
 	font-size: var(--ws-fs-path);
+	align-self: stretch;
+	max-width: 100%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .shell-sidebar__processes {

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -555,51 +555,60 @@ select {
 }
 
 .shell-sidebar[data-collapsed="true"] {
-	padding-inline: 8px;
+	/* Even padding on all four sides (was padding-inline: 8px only). */
+	padding: var(--space-3);
 }
 
 .shell-sidebar[data-collapsed="true"] .shell-sidebar__header {
-	justify-content: center;
-	/* collapsed sidebar uses 8px inset, so match the full-bleed cancel to 8px */
-	margin-inline: -8px;
-	padding-inline: 8px;
+	justify-content: flex-end;
+	margin-inline: calc(-1 * var(--space-3));
+	padding-inline: var(--space-3);
 }
 
 .shell-sidebar[data-collapsed="true"] .shell-sidebar__list {
-	align-items: center;
+	align-items: stretch;
 }
 
-/* Collapsed: flatten the worktree tree — no rail gutter, no connector pseudos,
-   no card boxes; just centered marker glyphs. (The collapsed CSS predated the
-   .shell-sidebar__node tree restructure, which is why the rail leaked through.) */
+/* Collapsed = compact git tree (~100px): KEEP the rail + connectors, but show
+   single-letter leaf markers instead of full cards, left-aligned. */
 .shell-sidebar[data-collapsed="true"] .shell-sidebar__workspace-items {
-	align-items: center;
-}
-.shell-sidebar[data-collapsed="true"] .shell-sidebar__node {
-	padding-left: 0;
-	padding-bottom: var(--space-1);
-}
-.shell-sidebar[data-collapsed="true"] .shell-sidebar__node::before,
-.shell-sidebar[data-collapsed="true"] .shell-sidebar__node::after {
-	display: none;
+	align-items: stretch;
 }
 .shell-sidebar[data-collapsed="true"] .shell-sidebar__row {
 	background: transparent;
 	border-color: transparent;
 	padding: 0;
 }
+/* The marker is a single line, so pull the elbow / trunk-stop up to its center
+   (vs the taller multi-line card the default 17px targets). */
+.shell-sidebar[data-collapsed="true"] .shell-sidebar__node::after {
+	top: 10px;
+}
+.shell-sidebar[data-collapsed="true"] .shell-sidebar__node:last-child::before {
+	height: 10px;
+}
 .shell-sidebar[data-collapsed="true"] .shell-sidebar__node--new button {
-	width: 40px;
+	width: auto;
 	min-width: 0;
-	padding: 0;
+	padding: 2px 6px;
 }
 
 .shell-sidebar[data-collapsed="true"] .shell-sidebar__item {
-	width: 40px;
-	height: 40px;
+	/* Leaf marker (single initial) sitting on the rail, not a 40px box. */
+	width: auto;
 	min-height: unset;
-	padding: 0;
-	justify-content: center;
+	padding: 2px 0;
+	justify-content: flex-start;
+}
+.shell-sidebar[data-collapsed="true"] .shell-sidebar__marker {
+	width: auto;
+	height: auto;
+}
+/* highlight the active worktree's marker (no card box in collapsed) */
+.shell-sidebar[data-collapsed="true"]
+	.shell-sidebar__row[data-selected="true"]
+	.shell-sidebar__marker {
+	color: var(--accent);
 }
 
 .shell-sidebar__marker {
@@ -1179,24 +1188,26 @@ select {
 }
 
 .shell-sidebar[data-collapsed="true"] .shell-sidebar__workspace-group {
-	align-items: center;
-	padding: 0;
+	align-items: stretch;
+	padding: var(--space-3) 0 var(--space-1);
 	background: transparent;
 	border: none;
 }
 
 .shell-sidebar[data-collapsed="true"] .shell-sidebar__workspace-header {
-	justify-content: center;
+	justify-content: flex-start;
+	padding-left: 4px;
 }
 
-/* collapsed badge: git icon + initial side-by-side, no pill background */
+/* collapsed badge: git icon + initial, left-aligned (the rail descends under it) */
 .shell-sidebar[data-collapsed="true"] .shell-sidebar__workspace-badge {
 	flex-direction: row;
-	gap: 5px;
+	gap: var(--space-1);
 	width: auto;
 	height: auto;
 	background: transparent;
 	border-radius: 0;
+	justify-content: flex-start;
 }
 
 .shell-sidebar__workspace-badge-initial {

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -606,11 +606,14 @@ select {
 	width: auto;
 	height: auto;
 }
-/* highlight the active worktree's marker (no card box in collapsed) */
+/* highlight the active worktree's marker (no card box in collapsed). Use
+   --primary (the cursor/accent colour, high-contrast in every theme) — the
+   --accent token is a low-contrast dark step in tui, so the initial vanished. */
 .shell-sidebar[data-collapsed="true"]
 	.shell-sidebar__row[data-selected="true"]
 	.shell-sidebar__marker {
-	color: var(--accent);
+	color: var(--primary);
+	font-weight: 700;
 }
 
 .shell-sidebar__marker {

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -722,8 +722,8 @@ select {
 .shell-sidebar__node {
 	position: relative;
 	padding-left: 24px;
-	/* Gap between cards — matches the prototype's ~4px card spacing (was 8px). */
-	padding-bottom: var(--space-1);
+	/* Gap between cards — matches the prototype's 2px card spacing. */
+	padding-bottom: 2px;
 }
 
 .shell-sidebar__node:last-child {

--- a/src/components/ui/icon.tsx
+++ b/src/components/ui/icon.tsx
@@ -26,7 +26,7 @@ export const ICON_GLYPHS = {
 	"arrow-right": { fallback: "→", nf: "" }, // arrow-right
 	plus: { fallback: "＋", nf: "" }, // plus
 	gear: { fallback: "⚙", nf: "" }, // cog
-	"git-branch": { fallback: "⎇", nf: "" }, // nf-dev-git_branch (powerline branch U+E0A0)
+	"git-branch": { fallback: "⎇", nf: "" }, // octicon git-branch U+F418
 	palette: { fallback: "🎨", nf: "" }, // nf-fa-paint_brush (FontAwesome paint-brush U+F1FC)
 	grid: { fallback: "▦", nf: "" }, // grid (th)
 	"external-link": { fallback: "↗", nf: "" }, // external-link

--- a/src/components/ui/icon.tsx
+++ b/src/components/ui/icon.tsx
@@ -26,8 +26,8 @@ export const ICON_GLYPHS = {
 	"arrow-right": { fallback: "→", nf: "" }, // arrow-right
 	plus: { fallback: "＋", nf: "" }, // plus
 	gear: { fallback: "⚙", nf: "" }, // cog
-	"git-branch": { fallback: "⎇", nf: "" }, // nf-dev-git_branch
-	palette: { fallback: "🎨", nf: "" }, // nf-fa-paint_brush
+	"git-branch": { fallback: "⎇", nf: "" }, // nf-dev-git_branch (powerline branch U+E0A0)
+	palette: { fallback: "🎨", nf: "" }, // nf-fa-paint_brush (FontAwesome paint-brush U+F1FC)
 	grid: { fallback: "▦", nf: "" }, // grid (th)
 	"external-link": { fallback: "↗", nf: "" }, // external-link
 	edit: { fallback: "✎", nf: "" }, // pencil

--- a/src/components/ui/icon.tsx
+++ b/src/components/ui/icon.tsx
@@ -26,6 +26,8 @@ export const ICON_GLYPHS = {
 	"arrow-right": { fallback: "→", nf: "" }, // arrow-right
 	plus: { fallback: "＋", nf: "" }, // plus
 	gear: { fallback: "⚙", nf: "" }, // cog
+	"git-branch": { fallback: "⎇", nf: "" }, // nf-dev-git_branch
+	palette: { fallback: "🎨", nf: "" }, // nf-fa-paint_brush
 	grid: { fallback: "▦", nf: "" }, // grid (th)
 	"external-link": { fallback: "↗", nf: "" }, // external-link
 	edit: { fallback: "✎", nf: "" }, // pencil

--- a/src/components/ui/icon.tsx
+++ b/src/components/ui/icon.tsx
@@ -27,6 +27,8 @@ export const ICON_GLYPHS = {
 	plus: { fallback: "＋", nf: "" }, // plus
 	gear: { fallback: "⚙", nf: "" }, // cog
 	"git-branch": { fallback: "⎇", nf: "" }, // octicon git-branch U+F418
+	"sidebar-collapse": { fallback: "◧", nf: "" }, // octicon sidebar-collapse U+F514
+	"sidebar-expand": { fallback: "◨", nf: "" }, // octicon sidebar-expand U+F515
 	palette: { fallback: "🎨", nf: "" }, // fa-palette U+EFCC
 	grid: { fallback: "▦", nf: "" }, // grid (th)
 	"external-link": { fallback: "↗", nf: "" }, // external-link

--- a/src/components/ui/icon.tsx
+++ b/src/components/ui/icon.tsx
@@ -27,7 +27,7 @@ export const ICON_GLYPHS = {
 	plus: { fallback: "＋", nf: "" }, // plus
 	gear: { fallback: "⚙", nf: "" }, // cog
 	"git-branch": { fallback: "⎇", nf: "" }, // octicon git-branch U+F418
-	palette: { fallback: "🎨", nf: "" }, // nf-fa-paint_brush (FontAwesome paint-brush U+F1FC)
+	palette: { fallback: "🎨", nf: "" }, // fa-palette U+EFCC
 	grid: { fallback: "▦", nf: "" }, // grid (th)
 	"external-link": { fallback: "↗", nf: "" }, // external-link
 	edit: { fallback: "✎", nf: "" }, // pencil

--- a/src/components/ui/icon.tsx
+++ b/src/components/ui/icon.tsx
@@ -27,7 +27,7 @@ export const ICON_GLYPHS = {
 	plus: { fallback: "＋", nf: "" }, // plus
 	gear: { fallback: "⚙", nf: "" }, // cog
 	"git-branch": { fallback: "⎇", nf: "" }, // nf-dev-git_branch (powerline branch U+E0A0)
-	palette: { fallback: "🎨", nf: "" }, // nf-fa-paint_brush (FontAwesome paint-brush U+F1FC)
+	palette: { fallback: "🎨", nf: "" }, // nf-fa-paint_brush (FontAwesome paint-brush U+F1FC)
 	grid: { fallback: "▦", nf: "" }, // grid (th)
 	"external-link": { fallback: "↗", nf: "" }, // external-link
 	edit: { fallback: "✎", nf: "" }, // pencil

--- a/src/features/workspace/components/SessionSidebar.tsx
+++ b/src/features/workspace/components/SessionSidebar.tsx
@@ -19,6 +19,7 @@ import { displayTitle } from "../logic/session-display-title";
 import type { WorkflowRow as WorkflowRowModel } from "../../workflows/logic/workflow-lens";
 import { WorkflowRow } from "../../workflows/components/WorkflowRow";
 import { Icon } from "@/components/ui/icon";
+import type { Palette } from "../../../lib/use-theme";
 
 export type SessionSidebarWorkspace = {
 	workspaceId: string;
@@ -66,9 +67,16 @@ type Props = {
 	) => void;
 	onOpenWorkflowDetail?: (workspaceId: string, worktreeId: string) => void;
 	pendingRename?: { workspaceId: string; worktreeId: string } | null;
-	palette?: "light" | "dark" | "warm" | "tui";
-	onSetTheme?: (mode: "light" | "dark" | "warm" | "tui") => void;
+	palette?: Palette;
+	onSetTheme?: (mode: Palette) => void;
 };
+
+const THEMES: { mode: Palette; label: string }[] = [
+	{ mode: "dark", label: "Dark" },
+	{ mode: "light", label: "Light" },
+	{ mode: "warm", label: "Warm" },
+	{ mode: "tui", label: "TUI" },
+];
 
 export function SessionSidebar({
 	workspaces,
@@ -133,13 +141,6 @@ export function SessionSidebar({
 	function cancelRename() {
 		setRenaming(null);
 	}
-
-	const THEMES: { mode: "light" | "dark" | "warm" | "tui"; label: string }[] = [
-		{ mode: "dark", label: "Dark" },
-		{ mode: "light", label: "Light" },
-		{ mode: "warm", label: "Warm" },
-		{ mode: "tui", label: "TUI" },
-	];
 
 	return (
 		<nav
@@ -606,6 +607,9 @@ export function SessionSidebar({
 									onSelect={() => onSetTheme(t.mode)}
 								>
 									{t.label}
+									{palette === t.mode && (
+										<Icon name="check" className="ml-auto" />
+									)}
 								</DropdownMenuItem>
 							))}
 						</DropdownMenuContent>

--- a/src/features/workspace/components/SessionSidebar.tsx
+++ b/src/features/workspace/components/SessionSidebar.tsx
@@ -159,9 +159,9 @@ export function SessionSidebar({
 				>
 					<span aria-hidden="true">
 						{collapsed ? (
-							<Icon name="caret-right" />
+							<Icon name="sidebar-expand" />
 						) : (
-							<Icon name="caret-left" />
+							<Icon name="sidebar-collapse" />
 						)}
 					</span>
 				</Button>

--- a/src/features/workspace/components/SessionSidebar.tsx
+++ b/src/features/workspace/components/SessionSidebar.tsx
@@ -6,6 +6,12 @@ import {
 	ContextMenuItem,
 	ContextMenuTrigger,
 } from "@/components/ui/context-menu";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import type { Worktree } from "../../../../shared/models/worktree";
 import type { ProcessAttentionState } from "../../../../shared/models/process-session";
 import type { WorktreeProcessSummary } from "../logic/sidebar-shell-summary";
@@ -60,6 +66,8 @@ type Props = {
 	) => void;
 	onOpenWorkflowDetail?: (workspaceId: string, worktreeId: string) => void;
 	pendingRename?: { workspaceId: string; worktreeId: string } | null;
+	palette?: "light" | "dark" | "warm" | "tui";
+	onSetTheme?: (mode: "light" | "dark" | "warm" | "tui") => void;
 };
 
 export function SessionSidebar({
@@ -79,6 +87,8 @@ export function SessionSidebar({
 	onClearFailedReason,
 	onOpenWorkflowDetail,
 	pendingRename,
+	palette,
+	onSetTheme,
 }: Props) {
 	const [renaming, setRenaming] = React.useState<{
 		workspaceId: string;
@@ -123,6 +133,13 @@ export function SessionSidebar({
 	function cancelRename() {
 		setRenaming(null);
 	}
+
+	const THEMES: { mode: "light" | "dark" | "warm" | "tui"; label: string }[] = [
+		{ mode: "dark", label: "Dark" },
+		{ mode: "light", label: "Light" },
+		{ mode: "warm", label: "Warm" },
+		{ mode: "tui", label: "TUI" },
+	];
 
 	return (
 		<nav
@@ -567,6 +584,33 @@ export function SessionSidebar({
 				>
 					{collapsed ? "Load" : "Load workspace"}
 				</Button>
+				{onSetTheme && (
+					<DropdownMenu>
+						<DropdownMenuTrigger asChild>
+							<Button
+								type="button"
+								variant="ghost"
+								size="icon"
+								className="shell-sidebar__theme-trigger"
+								aria-label="Switch theme"
+							>
+								<Icon name="palette" />
+							</Button>
+						</DropdownMenuTrigger>
+						<DropdownMenuContent align="end" className="shell-toolbar-menu">
+							{THEMES.map((t) => (
+								<DropdownMenuItem
+									key={t.mode}
+									className="shell-toolbar-menu__item"
+									data-active={String(palette === t.mode)}
+									onSelect={() => onSetTheme(t.mode)}
+								>
+									{t.label}
+								</DropdownMenuItem>
+							))}
+						</DropdownMenuContent>
+					</DropdownMenu>
+				)}
 			</div>
 		</nav>
 	);

--- a/src/features/workspace/components/SessionSidebar.tsx
+++ b/src/features/workspace/components/SessionSidebar.tsx
@@ -159,9 +159,9 @@ export function SessionSidebar({
 				>
 					<span aria-hidden="true">
 						{collapsed ? (
-							<Icon name="sidebar-expand" />
-						) : (
 							<Icon name="sidebar-collapse" />
+						) : (
+							<Icon name="sidebar-expand" />
 						)}
 					</span>
 				</Button>
@@ -558,9 +558,9 @@ export function SessionSidebar({
 										<div className="shell-sidebar__node shell-sidebar__node--new">
 											<Button
 												type="button"
-												variant="secondary"
+												variant="outline"
 												size="sm"
-												className="w-full"
+												className="w-full shadow-none"
 												onClick={() => onCreateWorktree(workspace.workspaceId)}
 												aria-label="New session"
 											>
@@ -579,7 +579,7 @@ export function SessionSidebar({
 					type="button"
 					variant="outline"
 					size="sm"
-					className="w-full"
+					className="w-full shadow-none"
 					onClick={onLoadWorkspace}
 					aria-label="Load workspace"
 				>

--- a/src/features/workspace/components/SessionSidebar.tsx
+++ b/src/features/workspace/components/SessionSidebar.tsx
@@ -155,383 +155,398 @@ export function SessionSidebar({
 						!collapsed &&
 						(collapsedWorkspaceIds?.includes(workspace.workspaceId) ?? false);
 					return (
-					<section
-						key={workspace.workspaceId}
-						role="group"
-						aria-label={workspace.name}
-						className="shell-sidebar__workspace-group"
-						data-active-workspace={String(workspace.active)}
-					>
-						<div className="shell-sidebar__workspace-header">
-							{collapsed ? (
-								<button
-									type="button"
-									className="shell-sidebar__workspace-badge"
-									title={workspace.name}
-									aria-label={workspace.name}
-									data-selected={String(workspace.active)}
-									onClick={() => onOpenWorkspace(workspace.workspaceId)}
-								>
-									{workspace.name.slice(0, 1).toUpperCase()}
-								</button>
-							) : (
-								<>
+						<section
+							key={workspace.workspaceId}
+							role="group"
+							aria-label={workspace.name}
+							className="shell-sidebar__workspace-group"
+							data-active-workspace={String(workspace.active)}
+						>
+							<div className="shell-sidebar__workspace-header">
+								{collapsed ? (
 									<button
 										type="button"
-										className="shell-sidebar__workspace-toggle"
-										aria-label={`${repoCollapsed ? "Expand" : "Collapse"} ${workspace.name}`}
-										aria-expanded={!repoCollapsed}
-										onClick={() =>
-											onToggleWorkspaceCollapsed?.(workspace.workspaceId)
-										}
-									>
-										<span className="shell-sidebar__chevron" aria-hidden="true">
-											<Icon
-												name={repoCollapsed ? "caret-right" : "caret-down"}
-											/>
-										</span>
-										<span
-											className="shell-sidebar__workspace-icon"
-											aria-hidden="true"
-										>
-											<Icon name="git-branch" />
-										</span>
-									</button>
-									<button
-										type="button"
-										className="shell-sidebar__workspace-name"
+										className="shell-sidebar__workspace-badge"
+										title={workspace.name}
+										aria-label={workspace.name}
 										data-selected={String(workspace.active)}
 										onClick={() => onOpenWorkspace(workspace.workspaceId)}
 									>
-										{workspace.name}
+										{workspace.name.slice(0, 1).toUpperCase()}
 									</button>
-									<Button
-										type="button"
-										variant="ghost"
-										size="icon"
-										className="shell-sidebar__workspace-remove"
-										aria-label={`Remove ${workspace.name}`}
-										onClick={() => onRemoveWorkspace(workspace.workspaceId)}
-									>
-										<Icon name="close" fallback="×" />
-									</Button>
-								</>
-							)}
-						</div>
-
-						{!repoCollapsed && (
-						<div className="shell-sidebar__workspace-items">
-							{workspace.worktrees.map((worktree) => {
-								const selected =
-									workspace.active &&
-									worktree.id === workspace.selectedWorktreeId;
-								const summary = workspace.processesByWorktreeId?.[worktree.id];
-								const rawTitle =
-									workspace.titleByWorktreeId?.[worktree.id] ?? "";
-								const shownTitle = displayTitle(rawTitle, worktree);
-								const hasCustomTitle = rawTitle.trim().length > 0;
-								const isRenamingThisRow =
-									renaming?.workspaceId === workspace.workspaceId &&
-									renaming?.worktreeId === worktree.id;
-
-								// Mirrored on the wrapper so CSS can frame the title button + process
-								// list as a single card; tests still read the attributes off the button.
-								const rowAttentionProps = {
-									"data-selected": String(selected),
-									"data-attention":
-										workspace.attentionByWorktreeId[worktree.id] ?? "idle",
-								};
-
-								const rowCommonProps = {
-									className: "shell-sidebar__item",
-									...rowAttentionProps,
-									"aria-label":
-										worktree.branchName !== shownTitle
-											? `${shownTitle} ${worktree.branchName}`
-											: shownTitle,
-								};
-
-								const rowContents = isRenamingThisRow ? (
-									<input
-										autoFocus
-										aria-label="Rename session"
-										className="shell-sidebar__rename-input"
-										value={draft}
-										onChange={(e) => setDraft(e.target.value)}
-										onKeyDown={(e) => {
-											if (e.key === "Enter") {
-												e.preventDefault();
-												commitRename(workspace.workspaceId, worktree.id);
-											} else if (e.key === "Escape") {
-												e.preventDefault();
-												cancelRename();
-											}
-										}}
-										onBlur={() =>
-											commitRename(workspace.workspaceId, worktree.id)
-										}
-									/>
-								) : collapsed ? (
-									<span className="shell-sidebar__marker">
-										{shownTitle.slice(0, 1).toUpperCase()}
-									</span>
 								) : (
 									<>
-										<strong
-											onDoubleClick={(e) => {
-												if (!workspace.active) return;
-												e.stopPropagation();
-												startRename(
-													workspace.workspaceId,
-													worktree.id,
-													rawTitle,
-												);
-											}}
+										<button
+											type="button"
+											className="shell-sidebar__workspace-toggle"
+											aria-label={`${repoCollapsed ? "Expand" : "Collapse"} ${workspace.name}`}
+											aria-expanded={!repoCollapsed}
+											onClick={() =>
+												onToggleWorkspaceCollapsed?.(workspace.workspaceId)
+											}
 										>
-											{shownTitle}
-										</strong>
-										{hasCustomTitle && (
-											<div className="shell-sidebar__worktree-label">
-												{worktree.label}
-											</div>
-										)}
-										{worktree.branchName !== worktree.label && (
-											<div className="shell-sidebar__branch">
-												{worktree.branchName}
-											</div>
-										)}
+											<span
+												className="shell-sidebar__chevron"
+												aria-hidden="true"
+											>
+												<Icon
+													name={repoCollapsed ? "caret-right" : "caret-down"}
+												/>
+											</span>
+											<span
+												className="shell-sidebar__workspace-icon"
+												aria-hidden="true"
+											>
+												<Icon name="git-branch" />
+											</span>
+										</button>
+										<button
+											type="button"
+											className="shell-sidebar__workspace-name"
+											data-selected={String(workspace.active)}
+											onClick={() => onOpenWorkspace(workspace.workspaceId)}
+										>
+											{workspace.name}
+										</button>
+										<Button
+											type="button"
+											variant="ghost"
+											size="icon"
+											className="shell-sidebar__workspace-remove"
+											aria-label={`Remove ${workspace.name}`}
+											onClick={() => onRemoveWorkspace(workspace.workspaceId)}
+										>
+											<Icon name="close" fallback="×" />
+										</Button>
 									</>
-								);
+								)}
+							</div>
 
-								const task = workspace.taskByWorktreeId?.[worktree.id];
-								const taskLine =
-									!isRenamingThisRow && !collapsed && task ? (
-										<div className="shell-sidebar__card-task" title={task}>
-											{task}
-										</div>
-									) : null;
+							{!repoCollapsed && (
+								<div className="shell-sidebar__workspace-items">
+									{workspace.worktrees.map((worktree) => {
+										const selected =
+											workspace.active &&
+											worktree.id === workspace.selectedWorktreeId;
+										const summary =
+											workspace.processesByWorktreeId?.[worktree.id];
+										const rawTitle =
+											workspace.titleByWorktreeId?.[worktree.id] ?? "";
+										const shownTitle = displayTitle(rawTitle, worktree);
+										const hasCustomTitle = rawTitle.trim().length > 0;
+										const isRenamingThisRow =
+											renaming?.workspaceId === workspace.workspaceId &&
+											renaming?.worktreeId === worktree.id;
 
-								// Process list rendered outside the row button to avoid nested <button> elements.
-								const sessionAttentionContext =
-									workspace.attentionContextByWorktreeId?.[worktree.id];
-								const processList =
-									!isRenamingThisRow &&
-									!collapsed &&
-									(summary || sessionAttentionContext) ? (
-										<div className="shell-sidebar__processes">
-											{sessionAttentionContext ? (
-												<div className="shell-sidebar__process shell-sidebar__process--session">
-													<span
-														className="shell-sidebar__process-context"
-														title={sessionAttentionContext}
-													>
-														{sessionAttentionContext}
-													</span>
-												</div>
-											) : null}
-											{summary?.rows.map((row) => (
-												<div key={row.id} className="shell-sidebar__process">
-													<span
-														data-testid="process-state-indicator"
-														className="shell-sidebar__process-indicator"
-														data-state={row.state}
-													/>
-													{row.provider && (
-														<span
-															className="shell-sidebar__provider-badge"
-															data-provider={row.provider}
-														>
-															{row.provider}
-														</span>
-													)}
-													<span
-														className="shell-sidebar__process-label"
-														title={row.label}
-													>
-														{row.label}
-													</span>
-													{row.context ? (
-														<span
-															className="shell-sidebar__process-context"
-															title={row.context}
-														>
-															{row.context}
-														</span>
-													) : null}
-													{row.hasFailedReason &&
-													onClearFailedReason &&
-													workspace.active ? (
-														<Button
-															type="button"
-															variant="secondary"
-															size="sm"
-															className="shell-sidebar__process-clear-failed"
-															aria-label={`Clear failed for ${row.label}`}
-															onClick={(e) => {
-																e.stopPropagation();
-																onClearFailedReason(
-																	workspace.workspaceId,
-																	worktree.id,
-																	row.id,
-																);
-															}}
-														>
-															Clear failed
-														</Button>
-													) : null}
-												</div>
-											))}
-											{summary && summary.overflowCount > 0 && (
-												<div className="shell-sidebar__process shell-sidebar__process--overflow">
-													{summary.overflowCount} more shell
-													{summary.overflowCount === 1 ? "" : "s"}
-												</div>
-											)}
-										</div>
-									) : null;
+										// Mirrored on the wrapper so CSS can frame the title button + process
+										// list as a single card; tests still read the attributes off the button.
+										const rowAttentionProps = {
+											"data-selected": String(selected),
+											"data-attention":
+												workspace.attentionByWorktreeId[worktree.id] ?? "idle",
+										};
 
-								// Workflow lens row: only present when whisper state exists for
-								// this worktree, and never while renaming or collapsed.
-								const workflowRowModel =
-									workspace.workflowRowByWorktreeId?.[worktree.id];
-								const workflowRow =
-									!isRenamingThisRow && !collapsed && workflowRowModel ? (
-										<WorkflowRow
-											row={workflowRowModel}
-											onOpenDetail={() =>
-												onOpenWorkflowDetail?.(
-													workspace.workspaceId,
-													worktree.id,
-												)
-											}
-										/>
-									) : null;
+										const rowCommonProps = {
+											className: "shell-sidebar__item",
+											...rowAttentionProps,
+											"aria-label":
+												worktree.branchName !== shownTitle
+													? `${shownTitle} ${worktree.branchName}`
+													: shownTitle,
+										};
 
-								const item = isRenamingThisRow ? (
-									<div role="presentation" {...rowCommonProps}>
-										{rowContents}
-									</div>
-								) : (
-									<button
-										type="button"
-										{...rowCommonProps}
-										onKeyDown={(e) => {
-											if (e.key === "F2") {
-												e.preventDefault();
-												if (collapsed || !workspace.active) {
-													onRequestExpand?.(workspace.workspaceId, worktree.id);
-													return;
+										const rowContents = isRenamingThisRow ? (
+											<input
+												autoFocus
+												aria-label="Rename session"
+												className="shell-sidebar__rename-input"
+												value={draft}
+												onChange={(e) => setDraft(e.target.value)}
+												onKeyDown={(e) => {
+													if (e.key === "Enter") {
+														e.preventDefault();
+														commitRename(workspace.workspaceId, worktree.id);
+													} else if (e.key === "Escape") {
+														e.preventDefault();
+														cancelRename();
+													}
+												}}
+												onBlur={() =>
+													commitRename(workspace.workspaceId, worktree.id)
 												}
-												startRename(
-													workspace.workspaceId,
-													worktree.id,
-													rawTitle,
-												);
-											}
-										}}
-									>
-										{rowContents}
-									</button>
-								);
-
-								// onClick on the wrapper makes the entire card (title + process list)
-								// the click target. Keyboard activation still flows through the inner
-								// <button>: pressing Enter/Space fires its native click which bubbles
-								// up to this handler. Inline-clickable children (Clear failed) stop
-								// propagation to keep their action separate from row selection.
-								const handleRowClick = isRenamingThisRow
-									? undefined
-									: () => onSelect(workspace.workspaceId, worktree.id);
-
-								if (collapsed || !workspace.active) {
-									return (
-										<div
-											key={worktree.id}
-											className="shell-sidebar__row"
-											{...rowAttentionProps}
-											onClick={handleRowClick}
-										>
-											{item}
-											{taskLine}
-											{processList}
-											{workflowRow}
-										</div>
-									);
-								}
-
-								return (
-									<ContextMenu key={worktree.id}>
-										<div
-											className="shell-sidebar__row"
-											{...rowAttentionProps}
-											onClick={handleRowClick}
-										>
-											<ContextMenuTrigger asChild>{item}</ContextMenuTrigger>
-											{taskLine}
-											{processList}
-											{workflowRow}
-										</div>
-										<ContextMenuContent className="shell-toolbar-menu">
-											<ContextMenuItem
-												className="shell-toolbar-menu__item"
-												onSelect={() => {
-													if (collapsed || !workspace.active) {
-														onRequestExpand?.(
+											/>
+										) : collapsed ? (
+											<span className="shell-sidebar__marker">
+												{shownTitle.slice(0, 1).toUpperCase()}
+											</span>
+										) : (
+											<>
+												<strong
+													onDoubleClick={(e) => {
+														if (!workspace.active) return;
+														e.stopPropagation();
+														startRename(
 															workspace.workspaceId,
 															worktree.id,
+															rawTitle,
 														);
-														return;
+													}}
+												>
+													{shownTitle}
+												</strong>
+												{hasCustomTitle && (
+													<div className="shell-sidebar__worktree-label">
+														{worktree.label}
+													</div>
+												)}
+												{worktree.branchName !== worktree.label && (
+													<div className="shell-sidebar__branch">
+														{worktree.branchName}
+													</div>
+												)}
+											</>
+										);
+
+										const task = workspace.taskByWorktreeId?.[worktree.id];
+										const taskLine =
+											!isRenamingThisRow && !collapsed && task ? (
+												<div className="shell-sidebar__card-task" title={task}>
+													{task}
+												</div>
+											) : null;
+
+										// Process list rendered outside the row button to avoid nested <button> elements.
+										const sessionAttentionContext =
+											workspace.attentionContextByWorktreeId?.[worktree.id];
+										const processList =
+											!isRenamingThisRow &&
+											!collapsed &&
+											(summary || sessionAttentionContext) ? (
+												<div className="shell-sidebar__processes">
+													{sessionAttentionContext ? (
+														<div className="shell-sidebar__process shell-sidebar__process--session">
+															<span
+																className="shell-sidebar__process-context"
+																title={sessionAttentionContext}
+															>
+																{sessionAttentionContext}
+															</span>
+														</div>
+													) : null}
+													{summary?.rows.map((row) => (
+														<div
+															key={row.id}
+															className="shell-sidebar__process"
+														>
+															<span
+																data-testid="process-state-indicator"
+																className="shell-sidebar__process-indicator"
+																data-state={row.state}
+															/>
+															{row.provider && (
+																<span
+																	className="shell-sidebar__provider-badge"
+																	data-provider={row.provider}
+																>
+																	{row.provider}
+																</span>
+															)}
+															<span
+																className="shell-sidebar__process-label"
+																title={row.label}
+															>
+																{row.label}
+															</span>
+															{row.context ? (
+																<span
+																	className="shell-sidebar__process-context"
+																	title={row.context}
+																>
+																	{row.context}
+																</span>
+															) : null}
+															{row.hasFailedReason &&
+															onClearFailedReason &&
+															workspace.active ? (
+																<Button
+																	type="button"
+																	variant="secondary"
+																	size="sm"
+																	className="shell-sidebar__process-clear-failed"
+																	aria-label={`Clear failed for ${row.label}`}
+																	onClick={(e) => {
+																		e.stopPropagation();
+																		onClearFailedReason(
+																			workspace.workspaceId,
+																			worktree.id,
+																			row.id,
+																		);
+																	}}
+																>
+																	Clear failed
+																</Button>
+															) : null}
+														</div>
+													))}
+													{summary && summary.overflowCount > 0 && (
+														<div className="shell-sidebar__process shell-sidebar__process--overflow">
+															{summary.overflowCount} more shell
+															{summary.overflowCount === 1 ? "" : "s"}
+														</div>
+													)}
+												</div>
+											) : null;
+
+										// Workflow lens row: only present when whisper state exists for
+										// this worktree, and never while renaming or collapsed.
+										const workflowRowModel =
+											workspace.workflowRowByWorktreeId?.[worktree.id];
+										const workflowRow =
+											!isRenamingThisRow && !collapsed && workflowRowModel ? (
+												<WorkflowRow
+													row={workflowRowModel}
+													onOpenDetail={() =>
+														onOpenWorkflowDetail?.(
+															workspace.workspaceId,
+															worktree.id,
+														)
 													}
-													startRename(
-														workspace.workspaceId,
-														worktree.id,
-														rawTitle,
-													);
+												/>
+											) : null;
+
+										const item = isRenamingThisRow ? (
+											<div role="presentation" {...rowCommonProps}>
+												{rowContents}
+											</div>
+										) : (
+											<button
+												type="button"
+												{...rowCommonProps}
+												onKeyDown={(e) => {
+													if (e.key === "F2") {
+														e.preventDefault();
+														if (collapsed || !workspace.active) {
+															onRequestExpand?.(
+																workspace.workspaceId,
+																worktree.id,
+															);
+															return;
+														}
+														startRename(
+															workspace.workspaceId,
+															worktree.id,
+															rawTitle,
+														);
+													}
 												}}
 											>
-												Rename session
-											</ContextMenuItem>
-											{!worktree.isMain && (
-												<ContextMenuItem
-													className="shell-toolbar-menu__item shell-toolbar-menu__item--danger"
-													onSelect={() =>
-														onRemoveWorktree(workspace.workspaceId, worktree.id)
-													}
-												>
-													Remove worktree
-												</ContextMenuItem>
-											)}
-										</ContextMenuContent>
-									</ContextMenu>
-								);
-							})}
+												{rowContents}
+											</button>
+										);
 
-							{workspace.worktrees.length === 0 && !collapsed && (
-								<div className="shell-sidebar__workspace-empty">
-									{workspace.hydrated
-										? "No worktree sessions yet."
-										: "Open this workspace to load its worktree sessions."}
+										// onClick on the wrapper makes the entire card (title + process list)
+										// the click target. Keyboard activation still flows through the inner
+										// <button>: pressing Enter/Space fires its native click which bubbles
+										// up to this handler. Inline-clickable children (Clear failed) stop
+										// propagation to keep their action separate from row selection.
+										const handleRowClick = isRenamingThisRow
+											? undefined
+											: () => onSelect(workspace.workspaceId, worktree.id);
+
+										if (collapsed || !workspace.active) {
+											return (
+												<div
+													key={worktree.id}
+													className="shell-sidebar__row"
+													{...rowAttentionProps}
+													onClick={handleRowClick}
+												>
+													{item}
+													{taskLine}
+													{processList}
+													{workflowRow}
+												</div>
+											);
+										}
+
+										return (
+											<ContextMenu key={worktree.id}>
+												<div
+													className="shell-sidebar__row"
+													{...rowAttentionProps}
+													onClick={handleRowClick}
+												>
+													<ContextMenuTrigger asChild>
+														{item}
+													</ContextMenuTrigger>
+													{taskLine}
+													{processList}
+													{workflowRow}
+												</div>
+												<ContextMenuContent className="shell-toolbar-menu">
+													<ContextMenuItem
+														className="shell-toolbar-menu__item"
+														onSelect={() => {
+															if (collapsed || !workspace.active) {
+																onRequestExpand?.(
+																	workspace.workspaceId,
+																	worktree.id,
+																);
+																return;
+															}
+															startRename(
+																workspace.workspaceId,
+																worktree.id,
+																rawTitle,
+															);
+														}}
+													>
+														Rename session
+													</ContextMenuItem>
+													{!worktree.isMain && (
+														<ContextMenuItem
+															className="shell-toolbar-menu__item shell-toolbar-menu__item--danger"
+															onSelect={() =>
+																onRemoveWorktree(
+																	workspace.workspaceId,
+																	worktree.id,
+																)
+															}
+														>
+															Remove worktree
+														</ContextMenuItem>
+													)}
+												</ContextMenuContent>
+											</ContextMenu>
+										);
+									})}
+
+									{workspace.worktrees.length === 0 && !collapsed && (
+										<div className="shell-sidebar__workspace-empty">
+											{workspace.hydrated
+												? "No worktree sessions yet."
+												: "Open this workspace to load its worktree sessions."}
+										</div>
+									)}
 								</div>
 							)}
-						</div>
-						)}
 
-						{workspace.active && (
-							<div className="shell-sidebar__footer">
-								<Button
-									type="button"
-									variant="secondary"
-									size="sm"
-									className="w-full"
-									onClick={() => onCreateWorktree(workspace.workspaceId)}
-									aria-label="New session"
-								>
-									{collapsed ? "+" : "+ New session"}
-								</Button>
-							</div>
-						)}
-					</section>
-				);
+							{workspace.active && (
+								<div className="shell-sidebar__footer">
+									<Button
+										type="button"
+										variant="secondary"
+										size="sm"
+										className="w-full"
+										onClick={() => onCreateWorktree(workspace.workspaceId)}
+										aria-label="New session"
+									>
+										{collapsed ? "+" : "+ New session"}
+									</Button>
+								</div>
+							)}
+						</section>
+					);
 				})}
 			</div>
 			<div className="shell-sidebar__footer shell-sidebar__footer--global">

--- a/src/features/workspace/components/SessionSidebar.tsx
+++ b/src/features/workspace/components/SessionSidebar.tsx
@@ -172,7 +172,12 @@ export function SessionSidebar({
 										data-selected={String(workspace.active)}
 										onClick={() => onOpenWorkspace(workspace.workspaceId)}
 									>
-										{workspace.name.slice(0, 1).toUpperCase()}
+										<span aria-hidden="true">
+											<Icon name="git-branch" />
+										</span>
+										<span className="shell-sidebar__workspace-badge-initial">
+											{workspace.name.slice(0, 1).toUpperCase()}
+										</span>
 									</button>
 								) : (
 									<>
@@ -455,69 +460,72 @@ export function SessionSidebar({
 
 										if (collapsed || !workspace.active) {
 											return (
-												<div
-													key={worktree.id}
-													className="shell-sidebar__row"
-													{...rowAttentionProps}
-													onClick={handleRowClick}
-												>
-													{item}
-													{taskLine}
-													{processList}
-													{workflowRow}
+												<div className="shell-sidebar__node" key={worktree.id}>
+													<div
+														className="shell-sidebar__row"
+														{...rowAttentionProps}
+														onClick={handleRowClick}
+													>
+														{item}
+														{taskLine}
+														{processList}
+														{workflowRow}
+													</div>
 												</div>
 											);
 										}
 
 										return (
-											<ContextMenu key={worktree.id}>
-												<div
-													className="shell-sidebar__row"
-													{...rowAttentionProps}
-													onClick={handleRowClick}
-												>
-													<ContextMenuTrigger asChild>
-														{item}
-													</ContextMenuTrigger>
-													{taskLine}
-													{processList}
-													{workflowRow}
-												</div>
-												<ContextMenuContent className="shell-toolbar-menu">
-													<ContextMenuItem
-														className="shell-toolbar-menu__item"
-														onSelect={() => {
-															if (collapsed || !workspace.active) {
-																onRequestExpand?.(
-																	workspace.workspaceId,
-																	worktree.id,
-																);
-																return;
-															}
-															startRename(
-																workspace.workspaceId,
-																worktree.id,
-																rawTitle,
-															);
-														}}
+											<div className="shell-sidebar__node" key={worktree.id}>
+												<ContextMenu>
+													<div
+														className="shell-sidebar__row"
+														{...rowAttentionProps}
+														onClick={handleRowClick}
 													>
-														Rename session
-													</ContextMenuItem>
-													{!worktree.isMain && (
+														<ContextMenuTrigger asChild>
+															{item}
+														</ContextMenuTrigger>
+														{taskLine}
+														{processList}
+														{workflowRow}
+													</div>
+													<ContextMenuContent className="shell-toolbar-menu">
 														<ContextMenuItem
-															className="shell-toolbar-menu__item shell-toolbar-menu__item--danger"
-															onSelect={() =>
-																onRemoveWorktree(
+															className="shell-toolbar-menu__item"
+															onSelect={() => {
+																if (collapsed || !workspace.active) {
+																	onRequestExpand?.(
+																		workspace.workspaceId,
+																		worktree.id,
+																	);
+																	return;
+																}
+																startRename(
 																	workspace.workspaceId,
 																	worktree.id,
-																)
-															}
+																	rawTitle,
+																);
+															}}
 														>
-															Remove worktree
+															Rename session
 														</ContextMenuItem>
-													)}
-												</ContextMenuContent>
-											</ContextMenu>
+														{!worktree.isMain && (
+															<ContextMenuItem
+																className="shell-toolbar-menu__item shell-toolbar-menu__item--danger"
+																onSelect={() =>
+																	onRemoveWorktree(
+																		workspace.workspaceId,
+																		worktree.id,
+																	)
+																}
+															>
+																Remove worktree
+															</ContextMenuItem>
+														)}
+													</ContextMenuContent>
+												</ContextMenu>
+											</div>
 										);
 									})}
 
@@ -528,21 +536,20 @@ export function SessionSidebar({
 												: "Open this workspace to load its worktree sessions."}
 										</div>
 									)}
-								</div>
-							)}
-
-							{workspace.active && (
-								<div className="shell-sidebar__footer">
-									<Button
-										type="button"
-										variant="secondary"
-										size="sm"
-										className="w-full"
-										onClick={() => onCreateWorktree(workspace.workspaceId)}
-										aria-label="New session"
-									>
-										{collapsed ? "+" : "+ New session"}
-									</Button>
+									{workspace.active && (
+										<div className="shell-sidebar__node shell-sidebar__node--new">
+											<Button
+												type="button"
+												variant="secondary"
+												size="sm"
+												className="w-full"
+												onClick={() => onCreateWorktree(workspace.workspaceId)}
+												aria-label="New session"
+											>
+												{collapsed ? "+" : "+ New session"}
+											</Button>
+										</div>
+									)}
 								</div>
 							)}
 						</section>

--- a/src/features/workspace/components/SessionSidebar.tsx
+++ b/src/features/workspace/components/SessionSidebar.tsx
@@ -45,6 +45,8 @@ type Props = {
 	onCreateWorktree: (workspaceId: string) => void;
 	onRemoveWorktree: (workspaceId: string, worktreeId: string) => void;
 	onRemoveWorkspace: (workspaceId: string) => void;
+	collapsedWorkspaceIds?: string[];
+	onToggleWorkspaceCollapsed?: (workspaceId: string) => void;
 	onRenameSession?: (
 		workspaceId: string,
 		worktreeId: string,
@@ -70,6 +72,8 @@ export function SessionSidebar({
 	onCreateWorktree,
 	onRemoveWorktree,
 	onRemoveWorkspace,
+	collapsedWorkspaceIds,
+	onToggleWorkspaceCollapsed,
 	onRenameSession,
 	onRequestExpand,
 	onClearFailedReason,
@@ -146,7 +150,11 @@ export function SessionSidebar({
 			</div>
 
 			<div className="shell-sidebar__list">
-				{workspaces.map((workspace) => (
+				{workspaces.map((workspace) => {
+					const repoCollapsed =
+						!collapsed &&
+						(collapsedWorkspaceIds?.includes(workspace.workspaceId) ?? false);
+					return (
 					<section
 						key={workspace.workspaceId}
 						role="group"
@@ -170,6 +178,27 @@ export function SessionSidebar({
 								<>
 									<button
 										type="button"
+										className="shell-sidebar__workspace-toggle"
+										aria-label={`${repoCollapsed ? "Expand" : "Collapse"} ${workspace.name}`}
+										aria-expanded={!repoCollapsed}
+										onClick={() =>
+											onToggleWorkspaceCollapsed?.(workspace.workspaceId)
+										}
+									>
+										<span className="shell-sidebar__chevron" aria-hidden="true">
+											<Icon
+												name={repoCollapsed ? "caret-right" : "caret-down"}
+											/>
+										</span>
+										<span
+											className="shell-sidebar__workspace-icon"
+											aria-hidden="true"
+										>
+											<Icon name="git-branch" />
+										</span>
+									</button>
+									<button
+										type="button"
 										className="shell-sidebar__workspace-name"
 										data-selected={String(workspace.active)}
 										onClick={() => onOpenWorkspace(workspace.workspaceId)}
@@ -180,6 +209,7 @@ export function SessionSidebar({
 										type="button"
 										variant="ghost"
 										size="icon"
+										className="shell-sidebar__workspace-remove"
 										aria-label={`Remove ${workspace.name}`}
 										onClick={() => onRemoveWorkspace(workspace.workspaceId)}
 									>
@@ -189,6 +219,7 @@ export function SessionSidebar({
 							)}
 						</div>
 
+						{!repoCollapsed && (
 						<div className="shell-sidebar__workspace-items">
 							{workspace.worktrees.map((worktree) => {
 								const selected =
@@ -483,6 +514,7 @@ export function SessionSidebar({
 								</div>
 							)}
 						</div>
+						)}
 
 						{workspace.active && (
 							<div className="shell-sidebar__footer">
@@ -499,7 +531,8 @@ export function SessionSidebar({
 							</div>
 						)}
 					</section>
-				))}
+				);
+				})}
 			</div>
 			<div className="shell-sidebar__footer shell-sidebar__footer--global">
 				<Button

--- a/src/features/workspace/logic/use-collapsed-workspaces.ts
+++ b/src/features/workspace/logic/use-collapsed-workspaces.ts
@@ -1,0 +1,38 @@
+import { useCallback, useState } from "react";
+
+const STORAGE_KEY = "ai14all.collapsedWorkspaces";
+
+function read(): string[] {
+	try {
+		const raw = localStorage.getItem(STORAGE_KEY);
+		const parsed = raw ? (JSON.parse(raw) as unknown) : [];
+		return Array.isArray(parsed)
+			? parsed.filter((x): x is string => typeof x === "string")
+			: [];
+	} catch {
+		return [];
+	}
+}
+
+export function useCollapsedWorkspaces(): {
+	collapsedIds: string[];
+	toggle: (id: string) => void;
+} {
+	const [collapsedIds, setCollapsedIds] = useState<string[]>(read);
+
+	const toggle = useCallback((id: string) => {
+		setCollapsedIds((prev) => {
+			const next = prev.includes(id)
+				? prev.filter((x) => x !== id)
+				: [...prev, id];
+			try {
+				localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+			} catch {
+				/* storage unavailable (e.g. private mode) — keep in-memory state */
+			}
+			return next;
+		});
+	}, []);
+
+	return { collapsedIds, toggle };
+}

--- a/src/lib/use-theme.ts
+++ b/src/lib/use-theme.ts
@@ -4,7 +4,7 @@ import type { Ai14AllDesktopApi } from "../../shared/contracts/commands";
 export type ThemeMode = "light" | "dark" | "system" | "warm" | "tui";
 export type ResolvedTheme = "light" | "dark";
 /** The value applied to the document's data-theme attribute. */
-type Palette = "light" | "dark" | "warm" | "tui";
+export type Palette = "light" | "dark" | "warm" | "tui";
 
 function getSystemTheme(): ResolvedTheme {
 	return window.matchMedia("(prefers-color-scheme: light)").matches

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -58,6 +58,14 @@
 	--space-5: 20px;
 	--space-6: 24px;
 
+	/* Workspace panel type ladder (docs/design-specs/2026-06-24-workspace-panel-rework-design.md §5) */
+	--ws-fs-header: 11px;
+	--ws-fs-repo: 15px;
+	--ws-fs-branch: 13px;
+	--ws-fs-path: 12px;
+	--ws-fs-chip: 11px;
+	--rail: oklch(0.42 0.02 256); /* solid tree-rail (dark default) */
+
 	color: var(--foreground);
 	background: var(--background);
 }
@@ -91,6 +99,7 @@
 	--input: oklch(0.6 0.04 257);
 	/* focus ring: 0.704 was 2.63:1; 0.55 -> 4.85:1 (WCAG 2.4.11). */
 	--ring: oklch(0.55 0.04 256.788);
+	--rail: oklch(0.80 0.012 256);
 	--accent: var(--primary);
 	/* AAA: 0.52 was ~5.54:1 (AA); 0.42 -> 8.58:1. */
 	--info: oklch(0.42 0.17 250);
@@ -112,6 +121,7 @@
 	/* focus ring: #6d5b46 was 2.60:1; #9a8266 -> 4.63:1 (WCAG 2.4.11). Control
 	 * borders (--input) are inherited white/15% = 3.38:1, already AA. */
 	--ring: #9a8266;
+	--rail: #6b5d48;
 	--primary: #e58a5e;
 	--primary-foreground: #221c15;
 	--secondary: #3d2817;
@@ -158,6 +168,7 @@
 	--border: oklch(0.34 0.015 240);
 	--input: oklch(0.26 0.015 240);
 	--ring: var(--primary);
+	--rail: oklch(0.44 0.015 240);
 
 	/* Character-grid tokens (spec §4.6): pin line-height so 1lh is
 	 * deterministic for cell-sized layout and box-drawing borders. */

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -99,7 +99,7 @@
 	--input: oklch(0.6 0.04 257);
 	/* focus ring: 0.704 was 2.63:1; 0.55 -> 4.85:1 (WCAG 2.4.11). */
 	--ring: oklch(0.55 0.04 256.788);
-	--rail: oklch(0.80 0.012 256);
+	--rail: oklch(0.8 0.012 256);
 	--accent: var(--primary);
 	/* AAA: 0.52 was ~5.54:1 (AA); 0.42 -> 8.58:1. */
 	--info: oklch(0.42 0.17 250);

--- a/tests/e2e/cumulative-flow.phase-6.test.ts
+++ b/tests/e2e/cumulative-flow.phase-6.test.ts
@@ -128,7 +128,7 @@ test.describe.serial("Cumulative flow — Phase 6", () => {
 		await worktreeNav.getByRole("button", { name: "Collapse sidebar" }).click();
 		await expect(shellLayout).toHaveAttribute(
 			"style",
-			/grid-template-columns:\s*68px minmax\(0px?,\s*1fr\)/,
+			/grid-template-columns:\s*88px minmax\(0px?,\s*1fr\)/,
 		);
 		await worktreeNav.getByRole("button", { name: "Expand sidebar" }).click();
 

--- a/tests/e2e/workspace-panel.screenshots.spec.ts
+++ b/tests/e2e/workspace-panel.screenshots.spec.ts
@@ -1,0 +1,142 @@
+import {
+	_electron as electron,
+	expect,
+	test,
+	type ElectronApplication,
+	type Page,
+} from "@playwright/test";
+import { mkdirSync, mkdtempSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createTestRepo, type TestRepo } from "./fixtures/create-test-repo";
+import { closeApp } from "./fixtures/close-app";
+
+/**
+ * Captures the reworked Workspace sidebar (nav[aria-label="Worktree sessions"])
+ * per theme (dark, light, warm, tui) to lock the visual result of the
+ * Workspace Panel Rework branch. Writes PNGs to tests/__screenshots__/.
+ *
+ * Run to create baselines:
+ *   pnpm test:e2e -- workspace-panel.screenshots --update-snapshots
+ * Run to verify stable:
+ *   pnpm test:e2e -- workspace-panel.screenshots
+ */
+
+const PALETTES = ["dark", "light", "warm", "tui"] as const;
+type Palette = (typeof PALETTES)[number];
+
+const OUT_DIR = join(
+	dirname(fileURLToPath(import.meta.url)),
+	"..",
+	"__screenshots__",
+);
+
+let app: ElectronApplication;
+let page: Page;
+let testRepo: TestRepo;
+
+test.beforeAll(async () => {
+	mkdirSync(OUT_DIR, { recursive: true });
+	testRepo = createTestRepo();
+	const stateDir = realpathSync(
+		mkdtempSync(join(tmpdir(), "ofa-workspace-panel-")),
+	);
+	app = await electron.launch({
+		args: ["out/main/index.js"],
+		env: {
+			...process.env,
+			AI14ALL_E2E: "1",
+			AI14ALL_E2E_PICK_PATH: testRepo.repoPath,
+			AI14ALL_WORKSPACE_STATE_PATH: join(stateDir, "workspace-state.json"),
+		},
+	});
+	page = await app.firstWindow({ timeout: 60_000 });
+
+	// AI14ALL_E2E_PICK_PATH fills the repo path field automatically (the
+	// "Browse" button seeds it), but the user still needs to click "Load".
+	await page.getByRole("button", { name: "Browse" }).click();
+	await expect(page.locator("#repo-path")).toHaveValue(testRepo.repoPath);
+	await page.getByRole("button", { name: "Load" }).click();
+
+	// Wait for the sidebar to be present and populated with at least one
+	// worktree item before we start taking screenshots.
+	const sidebar = page.getByRole("navigation", { name: "Worktree sessions" });
+	await expect(sidebar).toBeVisible({ timeout: 30_000 });
+	// Wait for worktree items to appear (the test repo has main + feature-a).
+	await expect(sidebar.locator(".shell-sidebar__item").first()).toBeVisible({
+		timeout: 15_000,
+	});
+});
+
+test.afterAll(async () => {
+	await closeApp(app);
+	testRepo?.cleanup();
+});
+
+async function setTheme(palette: Palette): Promise<void> {
+	await page.evaluate(
+		(t) => document.documentElement.setAttribute("data-theme", t),
+		palette,
+	);
+	await expect(page.locator("html")).toHaveAttribute("data-theme", palette);
+	// Allow theme-driven repaints (CSS custom properties, Nerd Font glyphs) to
+	// settle before capturing.
+	await page.waitForTimeout(200);
+}
+
+for (const palette of PALETTES) {
+	test(`workspace panel — ${palette} — expanded`, async () => {
+		await setTheme(palette);
+
+		const sidebar = page.getByRole("navigation", { name: "Worktree sessions" });
+		await expect(sidebar).toBeVisible();
+
+		// Ensure the panel is expanded (data-collapsed="false").
+		const isCollapsed = await sidebar.evaluate(
+			(el) => el.getAttribute("data-collapsed") === "true",
+		);
+		if (isCollapsed) {
+			await page.getByRole("button", { name: "Expand sidebar" }).click();
+			await expect(sidebar).toHaveAttribute("data-collapsed", "false");
+			await page.waitForTimeout(150);
+		}
+
+		await sidebar.screenshot({
+			path: join(OUT_DIR, `workspace-${palette}-expanded.png`),
+		});
+	});
+}
+
+for (const palette of PALETTES) {
+	test(`workspace panel — ${palette} — collapsed`, async () => {
+		await setTheme(palette);
+
+		const sidebar = page.getByRole("navigation", { name: "Worktree sessions" });
+		await expect(sidebar).toBeVisible();
+
+		// Ensure the panel is expanded first, then collapse it.
+		const isCollapsed = await sidebar.evaluate(
+			(el) => el.getAttribute("data-collapsed") === "true",
+		);
+		if (isCollapsed) {
+			await page.getByRole("button", { name: "Expand sidebar" }).click();
+			await expect(sidebar).toHaveAttribute("data-collapsed", "false");
+			await page.waitForTimeout(150);
+		}
+
+		// Now collapse the sidebar.
+		await page.getByRole("button", { name: "Collapse sidebar" }).click();
+		await expect(sidebar).toHaveAttribute("data-collapsed", "true");
+		await page.waitForTimeout(150);
+
+		await sidebar.screenshot({
+			path: join(OUT_DIR, `workspace-${palette}-collapsed.png`),
+		});
+
+		// Re-expand for subsequent tests.
+		await page.getByRole("button", { name: "Expand sidebar" }).click();
+		await expect(sidebar).toHaveAttribute("data-collapsed", "false");
+		await page.waitForTimeout(150);
+	});
+}

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,6 +1,35 @@
 import "@testing-library/jest-dom/vitest";
 import { vi } from "vitest";
 
+// Node 26 exposes a native `localStorage` global that is `undefined` when
+// `--localstorage-file` is not provided, shadowing jsdom's window.localStorage.
+// Polyfill it globally so tests can use bare `localStorage.*` as expected.
+if (typeof localStorage === "undefined") {
+	const store: Record<string, string> = {};
+	const localStorageMock = {
+		getItem: (key: string): string | null => store[key] ?? null,
+		setItem: (key: string, value: string): void => {
+			store[key] = String(value);
+		},
+		removeItem: (key: string): void => {
+			delete store[key];
+		},
+		clear: (): void => {
+			for (const key of Object.keys(store)) {
+				delete store[key];
+			}
+		},
+		get length(): number {
+			return Object.keys(store).length;
+		},
+		key: (index: number): string | null => Object.keys(store)[index] ?? null,
+	};
+	Object.defineProperty(globalThis, "localStorage", {
+		value: localStorageMock,
+		writable: true,
+	});
+}
+
 // Stub ResizeObserver for jsdom (not available in the test environment)
 global.ResizeObserver = class ResizeObserver {
 	observe() {}

--- a/tests/unit/components/App-phase-6-shell.test.tsx
+++ b/tests/unit/components/App-phase-6-shell.test.tsx
@@ -759,7 +759,7 @@ describe("App — Phase 6 default shell", () => {
 		);
 
 		expect(shellLayout).toHaveStyle({
-			gridTemplateColumns: "68px minmax(0, 1fr)",
+			gridTemplateColumns: "88px minmax(0, 1fr)",
 		});
 		expect(nav).toHaveAttribute("data-collapsed", "true");
 		expect(within(nav).queryByText("feature-a")).not.toBeInTheDocument();
@@ -827,7 +827,7 @@ describe("App — Phase 6 default shell", () => {
 		});
 	});
 
-	it("clamps sidebar width to minimum 180px", async () => {
+	it("clamps sidebar width to minimum 200px", async () => {
 		readRestoreStateMock.mockResolvedValue({
 			version: 1,
 			restorePreference: "prompt",
@@ -869,7 +869,7 @@ describe("App — Phase 6 default shell", () => {
 
 		await waitFor(() => {
 			expect(layout).toHaveStyle({
-				gridTemplateColumns: "180px minmax(0, 1fr)",
+				gridTemplateColumns: "200px minmax(0, 1fr)",
 			});
 		});
 	});
@@ -970,7 +970,7 @@ describe("App — Phase 6 default shell", () => {
 		});
 
 		const layout = screen.getByTestId("shell-layout");
-		expect(layout).toHaveStyle({ gridTemplateColumns: "68px minmax(0, 1fr)" });
+		expect(layout).toHaveStyle({ gridTemplateColumns: "88px minmax(0, 1fr)" });
 	});
 
 	it("preserves sidebar width after collapse and expand", async () => {
@@ -1027,7 +1027,7 @@ describe("App — Phase 6 default shell", () => {
 		await userEvent.click(collapseButton);
 		await waitFor(() => {
 			expect(layout).toHaveStyle({
-				gridTemplateColumns: "68px minmax(0, 1fr)",
+				gridTemplateColumns: "88px minmax(0, 1fr)",
 			});
 		});
 

--- a/tests/unit/components/Icon.test.tsx
+++ b/tests/unit/components/Icon.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { Icon, ICON_GLYPHS } from "../../../src/components/ui/icon";
+
+describe("Icon registry", () => {
+	it("includes git-branch and palette glyphs with fallbacks", () => {
+		expect(ICON_GLYPHS["git-branch"]?.fallback).toBeTruthy();
+		expect(ICON_GLYPHS["palette"]?.fallback).toBeTruthy();
+	});
+
+	it("renders a hidden text fallback for new icons", () => {
+		const { container } = render(<Icon name="git-branch" />);
+		expect(container.textContent).toContain(ICON_GLYPHS["git-branch"].fallback);
+	});
+});

--- a/tests/unit/components/SessionSidebar.test.tsx
+++ b/tests/unit/components/SessionSidebar.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { SessionSidebar } from "../../../src/features/workspace/components/SessionSidebar";
 import type { Worktree } from "../../../shared/models/worktree";
 
@@ -395,6 +396,32 @@ describe("SessionSidebar", () => {
 				name: "feature worktree feature-a",
 			}),
 		).toHaveAttribute("data-selected", "false");
+	});
+});
+
+describe("SessionSidebar theme switcher", () => {
+	it("invokes onSetTheme from the palette menu", async () => {
+		const onSetTheme = vi.fn();
+		const user = userEvent.setup();
+		render(
+			<SessionSidebar
+				workspaces={[{ ...workspaces[0], selectedWorktreeId: "main" }]}
+				collapsed={false}
+				onToggleCollapsed={vi.fn()}
+				onLoadWorkspace={vi.fn()}
+				onOpenWorkspace={vi.fn()}
+				onSelect={vi.fn()}
+				onCreateWorktree={vi.fn()}
+				onRemoveWorktree={vi.fn()}
+				onRemoveWorkspace={vi.fn()}
+				palette="dark"
+				onSetTheme={onSetTheme}
+			/>,
+		);
+		await user.click(screen.getByRole("button", { name: /switch theme/i }));
+		const warm = await screen.findByRole("menuitem", { name: /warm/i });
+		await user.click(warm);
+		expect(onSetTheme).toHaveBeenCalledWith("warm");
 	});
 });
 

--- a/tests/unit/components/SessionSidebar.test.tsx
+++ b/tests/unit/components/SessionSidebar.test.tsx
@@ -612,3 +612,46 @@ describe("SessionSidebar footer label", () => {
 		expect(btn.textContent).toBe("+ New session");
 	});
 });
+
+describe("SessionSidebar repo collapse", () => {
+	it("toggles a repo via the chevron", () => {
+		const onToggleWorkspaceCollapsed = vi.fn();
+		render(
+			<SessionSidebar
+				workspaces={[{ ...workspaces[0], selectedWorktreeId: "main" }]}
+				collapsed={false}
+				onToggleCollapsed={vi.fn()}
+				onLoadWorkspace={vi.fn()}
+				onOpenWorkspace={vi.fn()}
+				onSelect={vi.fn()}
+				onCreateWorktree={vi.fn()}
+				onRemoveWorktree={vi.fn()}
+				onRemoveWorkspace={vi.fn()}
+				onToggleWorkspaceCollapsed={onToggleWorkspaceCollapsed}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: /collapse repo-a/i }));
+		expect(onToggleWorkspaceCollapsed).toHaveBeenCalledWith("ws-a");
+	});
+
+	it("hides worktree items when the repo id is collapsed", () => {
+		render(
+			<SessionSidebar
+				workspaces={[{ ...workspaces[0], selectedWorktreeId: "main" }]}
+				collapsed={false}
+				onToggleCollapsed={vi.fn()}
+				onLoadWorkspace={vi.fn()}
+				onOpenWorkspace={vi.fn()}
+				onSelect={vi.fn()}
+				onCreateWorktree={vi.fn()}
+				onRemoveWorktree={vi.fn()}
+				onRemoveWorkspace={vi.fn()}
+				collapsedWorkspaceIds={["ws-a"]}
+				onToggleWorkspaceCollapsed={vi.fn()}
+			/>,
+		);
+		expect(screen.queryByText("feature worktree")).not.toBeInTheDocument();
+		// repo title still present
+		expect(screen.getByRole("button", { name: "repo-a" })).toBeInTheDocument();
+	});
+});

--- a/tests/unit/components/SessionSidebar.test.tsx
+++ b/tests/unit/components/SessionSidebar.test.tsx
@@ -423,6 +423,30 @@ describe("SessionSidebar theme switcher", () => {
 		await user.click(warm);
 		expect(onSetTheme).toHaveBeenCalledWith("warm");
 	});
+
+	it("shows a check mark on the active theme and not on inactive themes", async () => {
+		const user = userEvent.setup();
+		render(
+			<SessionSidebar
+				workspaces={[{ ...workspaces[0], selectedWorktreeId: "main" }]}
+				collapsed={false}
+				onToggleCollapsed={vi.fn()}
+				onLoadWorkspace={vi.fn()}
+				onOpenWorkspace={vi.fn()}
+				onSelect={vi.fn()}
+				onCreateWorktree={vi.fn()}
+				onRemoveWorktree={vi.fn()}
+				onRemoveWorkspace={vi.fn()}
+				palette="dark"
+				onSetTheme={vi.fn()}
+			/>,
+		);
+		await user.click(screen.getByRole("button", { name: /switch theme/i }));
+		const activeItem = await screen.findByRole("menuitem", { name: /dark/i });
+		const warmItem = await screen.findByRole("menuitem", { name: /warm/i });
+		expect(within(activeItem).queryByText("✓")).toBeInTheDocument();
+		expect(within(warmItem).queryByText("✓")).toBeNull();
+	});
 });
 
 import React from "react";
@@ -680,6 +704,10 @@ describe("SessionSidebar repo collapse", () => {
 		expect(screen.queryByText("feature worktree")).not.toBeInTheDocument();
 		// repo title still present
 		expect(screen.getByRole("button", { name: "repo-a" })).toBeInTheDocument();
+		// toggle button stays reachable when collapsed
+		expect(
+			screen.getByRole("button", { name: /expand repo-a/i }),
+		).toBeInTheDocument();
 	});
 });
 

--- a/tests/unit/components/SessionSidebar.test.tsx
+++ b/tests/unit/components/SessionSidebar.test.tsx
@@ -655,3 +655,50 @@ describe("SessionSidebar repo collapse", () => {
 		expect(screen.getByRole("button", { name: "repo-a" })).toBeInTheDocument();
 	});
 });
+
+describe("SessionSidebar tree rail + new button placement", () => {
+	it("wraps the New session button as the last node inside the items list", () => {
+		const { container } = render(
+			<SessionSidebar
+				workspaces={[{ ...workspaces[0], selectedWorktreeId: "main" }]}
+				collapsed={false}
+				onToggleCollapsed={vi.fn()}
+				onLoadWorkspace={vi.fn()}
+				onOpenWorkspace={vi.fn()}
+				onSelect={vi.fn()}
+				onCreateWorktree={vi.fn()}
+				onRemoveWorktree={vi.fn()}
+				onRemoveWorkspace={vi.fn()}
+			/>,
+		);
+		const items = container.querySelector(".shell-sidebar__workspace-items")!;
+		const last = items.lastElementChild!;
+		expect(last).toHaveClass("shell-sidebar__node");
+		expect(
+			within(last as HTMLElement).getByRole("button", { name: "New session" }),
+		).toBeInTheDocument();
+		// every worktree row is wrapped in a node
+		expect(items.querySelectorAll(".shell-sidebar__node").length).toBe(
+			workspaces[0].worktrees.length + 1,
+		);
+	});
+
+	it("collapsed badge keeps the workspace accessible name", () => {
+		render(
+			<SessionSidebar
+				workspaces={[{ ...workspaces[0], selectedWorktreeId: "main" }]}
+				collapsed={true}
+				onToggleCollapsed={vi.fn()}
+				onLoadWorkspace={vi.fn()}
+				onOpenWorkspace={vi.fn()}
+				onSelect={vi.fn()}
+				onCreateWorktree={vi.fn()}
+				onRemoveWorktree={vi.fn()}
+				onRemoveWorkspace={vi.fn()}
+			/>,
+		);
+		const badge = screen.getByRole("button", { name: "repo-a" });
+		expect(badge).toHaveClass("shell-sidebar__workspace-badge");
+		expect(badge.textContent).toContain("R"); // initial preserved beside the icon
+	});
+});

--- a/tests/unit/styles/workspace-tokens.test.ts
+++ b/tests/unit/styles/workspace-tokens.test.ts
@@ -4,7 +4,10 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const css = readFileSync(
-	resolve(dirname(fileURLToPath(import.meta.url)), "../../../src/styles/tokens.css"),
+	resolve(
+		dirname(fileURLToPath(import.meta.url)),
+		"../../../src/styles/tokens.css",
+	),
 	"utf8",
 );
 

--- a/tests/unit/styles/workspace-tokens.test.ts
+++ b/tests/unit/styles/workspace-tokens.test.ts
@@ -18,9 +18,9 @@ describe("workspace tokens", () => {
 	it("defines a solid --rail in every theme (no alpha)", () => {
 		// one in :root (dark) + light + warm + tui = 4 declarations
 		const decls = css.match(/--rail:\s*[^;]+;/g) ?? [];
-		expect(decls.length).toBeGreaterThanOrEqual(4);
+		expect(decls.length).toBe(4);
 		for (const d of decls) {
-			expect(d).not.toMatch(/color-mix|transparent|\/\s*\d/); // no alpha
+			expect(d).not.toMatch(/color-mix|transparent|\/\s*[\d.%]/); // no alpha
 		}
 	});
 });

--- a/tests/unit/styles/workspace-tokens.test.ts
+++ b/tests/unit/styles/workspace-tokens.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const css = readFileSync(
+	resolve(dirname(fileURLToPath(import.meta.url)), "../../../src/styles/tokens.css"),
+	"utf8",
+);
+
+describe("workspace tokens", () => {
+	it("defines the ws-fs ladder", () => {
+		for (const t of ["header", "repo", "branch", "path", "chip"]) {
+			expect(css).toContain(`--ws-fs-${t}:`);
+		}
+	});
+
+	it("defines a solid --rail in every theme (no alpha)", () => {
+		// one in :root (dark) + light + warm + tui = 4 declarations
+		const decls = css.match(/--rail:\s*[^;]+;/g) ?? [];
+		expect(decls.length).toBeGreaterThanOrEqual(4);
+		for (const d of decls) {
+			expect(d).not.toMatch(/color-mix|transparent|\/\s*\d/); // no alpha
+		}
+	});
+});

--- a/tests/unit/workspace/use-collapsed-workspaces.test.ts
+++ b/tests/unit/workspace/use-collapsed-workspaces.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useCollapsedWorkspaces } from "../../../src/features/workspace/logic/use-collapsed-workspaces";
+
+beforeEach(() => localStorage.clear());
+
+describe("useCollapsedWorkspaces", () => {
+	it("toggles ids and persists across remounts", () => {
+		const first = renderHook(() => useCollapsedWorkspaces());
+		act(() => first.result.current.toggle("ws-a"));
+		expect(first.result.current.collapsedIds).toEqual(["ws-a"]);
+
+		const second = renderHook(() => useCollapsedWorkspaces());
+		expect(second.result.current.collapsedIds).toEqual(["ws-a"]);
+
+		act(() => second.result.current.toggle("ws-a"));
+		expect(second.result.current.collapsedIds).toEqual([]);
+	});
+});


### PR DESCRIPTION
Restructures the left **Workspace** sidebar from a flat worktree list into a collapsible repo→worktree **git tree**, with a unified icon set, a tightened typography scale, a theme switcher, and a compact collapsed mini-tree. Built fresh from a user-approved interactive prototype.

Design docs: `docs/design-specs/2026-06-24-workspace-panel-rework-design.md` (+ `…-prototype.html`).

## Highlights
- **Git-tree rendering** — repo nodes with a 2px solid rail and `├─`/`└─` connectors to worktree rows (`.shell-sidebar__node` wrappers; rail kept off `.shell-sidebar__row::before`, which drives attention animations).
- **Per-repo collapse** — chevron + git-branch icon; state persisted to `localStorage` (`use-collapsed-workspaces.ts`).
- **Icons unified on `<Icon>`** — octicon git-branch + sidebar-collapse/expand, fa-palette theme switcher; codepoints confirmed against the bundled Symbols Nerd Font.
- **Typography ladder** (`--ws-fs-*`) + solid per-theme `--rail` token.
- **Theme switcher** — palette dropdown (dark/light/warm/tui) wired through `App → SidebarPanel → SessionSidebar` via `useTheme`, with an active-theme check.
- **Worktree rows** — title/branch ellipsis-clamp so long names truncate instead of spilling; only the active row is boxed.
- **Collapsed state** — compact mini git-tree at 88px: git icon + initial, rail with single-letter leaf markers, tight centered selection box, centered toggle, even padding.
- **Separators** restored as full-bleed/divider lines; **hover** highlights the icon/label (accent) with no background fill.
- Applies across **all four themes** (structural CSS in base selectors; colour via per-theme tokens).

## Layout / min-width
- `SIDEBAR_MIN` raised 180 → 200px (below 200 the list overhung and footer icons clipped).

## Testing
- Unit (Vitest): `SessionSidebar` (27), `Icon`, token guard, `use-collapsed-workspaces` — green. `typecheck` clean (3 tsconfigs); prettier/eslint clean on changed files (no new errors; pre-existing `react-hooks/exhaustive-deps` warnings in unrelated App.tsx code remain).
- e2e (Playwright): `tests/e2e/workspace-panel.screenshots.spec.ts` captures the panel per theme; extensively visually verified (expanded + collapsed, all four themes, hover, min-width).

🤖 Generated with [Claude Code](https://claude.com/claude-code)